### PR TITLE
add "ssh" backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Convenient full-system test (task) distribution
 [Including and excluding files](#including)  
 [Selecting which tasks to run](#selecting)  
 [LXD backend](#lxd)  
-[Linode backend](#linode)  
+[Linode backend](#linode)
+[SSH backend](#ssh)  
 [More on parallelism](#parallelism)  
 
 <a name="why"/>
@@ -663,6 +664,24 @@ Some links to make your life easier:
   * [Users and permissions](https://manager.linode.com/user)
   * [API keys](https://manager.linode.com/profile/api)
 
+<a name="ssh"/>
+ssh backend
+-----------
+
+The ssh backend depends on ssh only. It assumes you have a system
+prepared for testing using some other means.
+
+Example:
+```
+backends:
+    ssh:
+        systems:
+            - remotename-22
+```
+
+System names are mapped to ssh in the following way:
+
+  * name-port => name:port
 
 <a name="parallelism"/>
 More on parallelism

--- a/spread/project.go
+++ b/spread/project.go
@@ -261,7 +261,7 @@ func Load(path string) (*Project, error) {
 			backend.Type = bname
 		}
 		switch backend.Type {
-		case "linode", "lxd":
+		case "linode", "lxd", "ssh":
 		default:
 			return nil, fmt.Errorf("%s has unsupported type %q", backend, backend.Type)
 		}
@@ -900,4 +900,3 @@ func (t *Timeout) UnmarshalYAML(u func(interface{}) error) error {
 	t.Duration = d
 	return nil
 }
-

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -64,6 +64,8 @@ func Start(project *Project, options *Options) (*Runner, error) {
 			r.providers[bname] = Linode(backend)
 		case "lxd":
 			r.providers[bname] = LXD(backend)
+		case "ssh":
+			r.providers[bname] = SSH(backend)
 		default:
 			return nil, fmt.Errorf("%s has unsupported type %q", backend, backend.Type)
 		}

--- a/spread/ssh.go
+++ b/spread/ssh.go
@@ -1,0 +1,153 @@
+package spread
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func SSH(b *Backend) Provider {
+	return &sshBackend{b}
+}
+
+type sshBackend struct {
+	backend *Backend
+}
+
+type sshServer struct {
+	l *sshBackend
+	d sshServerData
+}
+
+type sshServerData struct {
+	Name    string
+	Backend string
+	System  string
+	Address string
+	Port    int
+}
+
+func (s *sshServer) String() string {
+	return fmt.Sprintf("%s:%s", s.l.backend.Name, s.d.System)
+}
+
+func (s *sshServer) Provider() Provider {
+	return s.l
+}
+
+func (s *sshServer) Address() string {
+	return s.d.Address
+}
+
+func (s *sshServer) Port() int {
+	return s.d.Port
+}
+
+func (s *sshServer) System() string {
+	return s.d.System
+}
+
+func (s *sshServer) ReuseData() []byte {
+	data, err := yaml.Marshal(&s.d)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func (s *sshServer) Discard() error {
+	return nil
+}
+
+func (l *sshBackend) Backend() *Backend {
+	return l.backend
+}
+
+func (l *sshBackend) Reuse(data []byte, password string) (Server, error) {
+	server := &sshServer{}
+	err := yaml.Unmarshal(data, &server.d)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal ssh reuse data: %v", err)
+	}
+	server.l = l
+	return server, nil
+}
+
+func (l *sshBackend) Allocate(system string, password string, keep bool) (Server, error) {
+	n := strings.LastIndex(system, "-")
+	name := system[:n]
+	port, err := strconv.Atoi(system[n+1:])
+	if err != nil {
+		return nil, err
+	}
+
+	server := &sshServer{
+		l: l,
+		d: sshServerData{
+			System:  name,
+			Address: name,
+			Port:    port,
+			// Name? Backend?
+		},
+	}
+
+	err = server.addRootUserSSH(password)
+	if err != nil {
+		server.Discard()
+		return nil, err
+	}
+
+	printf("Allocated %s.", server.String())
+	return server, nil
+}
+
+func (l *sshServer) sshConnect() (*ssh.Client, error) {
+	user := os.Getenv("SPREAD_SSH_USER")
+	if user == "" {
+		user = "ubuntu"
+	}
+	pw := os.Getenv("SPREAD_SSH_PASSWORD")
+	if pw == "" {
+		pw = "ubuntu"
+	}
+
+	config := &ssh.ClientConfig{
+		User:    user,
+		Auth:    []ssh.AuthMethod{ssh.Password(pw)},
+		Timeout: 10 * time.Second,
+	}
+	addr := fmt.Sprintf("%s:%d", l.Address(), l.Port())
+	return ssh.Dial("tcp", addr, config)
+}
+
+func (server *sshServer) addRootUserSSH(password string) error {
+	sshc, err := server.sshConnect()
+	if err != nil {
+		return fmt.Errorf("cannot connect to %s:%d: %s", server.Address(), server.Port(), err)
+	}
+	defer sshc.Close()
+
+	// enable ssh root login, set root password and restart sshd
+	cmds := []string{
+		`sudo sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config`,
+		fmt.Sprintf(`sudo /bin/bash -c "%s"`, fmt.Sprintf("echo root:%s | chpasswd", password)),
+		"sudo systemctl reload sshd",
+	}
+	for _, cmd := range cmds {
+		session, err := sshc.NewSession()
+		if err != nil {
+			return err
+		}
+		output, err := session.CombinedOutput(cmd)
+		session.Close()
+		if err != nil {
+			return fmt.Errorf("cannot prepare sshd in ssh container %q: %v", server.Port(), outputErr(output, err))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds a new `ssh` backend to spread. The idea behind it is that spread can run tests on systems that go provisioned by some other mechanism.

I plan to use this so that I can run the spread in the autopkgtest run. The idea is that inside the autopkgtest contains we run the spread tests against "ssh:localhost-22" with something like:
```
diff --git a/debian/tests/integrationtests b/debian/tests/integrationtests
index f8e8f32..2edb829 100644
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -43,7 +43,8 @@ if [ -z "$ADT_REBOOT_MARK" ]; then
     sudo cp $GOPATH/bin/snapbuild /usr/local/bin
 fi
 
+./spread -v ssh:
 
 if [ -e "${NEEDS_REBOOT}" ]; then
     mark=$(cat "${NEEDS_REBOOT}")
diff --git a/spread.yaml b/spread.yaml
index ecf7c9c..ccc2737 100644
--- a/spread.yaml
+++ b/spread.yaml
@@ -13,6 +13,12 @@ backends:
         systems:
             - ubuntu-16.04-64-grub
             - ubuntu-16.04-32-grub
+    ssh:
+      systems:
+        - localhost-22
 
 path: $[PROJECT_PATH]

```