### PR TITLE
fix crash when we run spread -l on snapd

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -720,6 +720,10 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 
 				for _, sysname := range systems {
 					system := backend.Systems[sysname]
+					// not for us
+					if system == nil {
+						continue
+					}
 					yenv := envmap{system, system.Environment}
 					yevr := strmap{system, evars(system.Environment, "+")}
 					yvar := strmap{system, system.Variants}


### PR DESCRIPTION
Trivial fix for a panic() when `spread -l` is run inside the snapd source tree. The reason for the crash is that the unity test has `systems: [ubuntu-16.04-64-grub]` so it is not available on the qemu backend.