### PR TITLE
Add a reboot/resume message for -v

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -215,6 +215,7 @@ func (c *Client) run(script string, dir string, env *Environment, mode int) (out
 	for _, script := range scripts[1:] {
 		output = append(output, "\n<REBOOTED>\n\n"...)
 
+		printf("Requesting reboot for %s", c.server)
 		err := c.Run("reboot &\nsleep 60", "", nil)
 		if err != nil {
 			err = c.Run("echo should-have-disconnected", "", nil)
@@ -226,6 +227,7 @@ func (c *Client) run(script string, dir string, env *Environment, mode int) (out
 		if err := c.dialOnReboot(); err != nil {
 			return nil, err
 		}
+		printf("Resuming %s after reboot", c.server)
 
 		output, err = c.runPart(script, dir, env, mode, output)
 		if err != nil {

--- a/spread/project.go
+++ b/spread/project.go
@@ -720,6 +720,10 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 
 				for _, sysname := range systems {
 					system := backend.Systems[sysname]
+					// not for us
+					if system == nil {
+						continue
+					}
 					yenv := envmap{system, system.Environment}
 					yevr := strmap{system, evars(system.Environment, "+")}
 					yvar := strmap{system, system.Variants}


### PR DESCRIPTION
I found it helpful to see when the machine reports (when running with -v). Mostly to understand why some tests took a bit longer (or were hanging when a reboot would not return at all). Feel free to ignore if you think this only adds clutter.
