### PR TITLE
Skip file in the suites tests path

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -537,6 +537,9 @@ func Load(path string) (*Project, error) {
 		suite.Tasks = make(map[string]*Task)
 		for _, tname := range tnames {
 			tfilename := filepath.Join(suite.Path, tname, "task.yaml")
+			if fi, _ := os.Stat(filepath.Dir(tfilename)); !fi.IsDir() {
+				continue
+			}
 			tdata, err := ioutil.ReadFile(tfilename)
 			if os.IsNotExist(err) {
 				debugf("Skipping %s/%s: task.yaml missing", sname, tname)


### PR DESCRIPTION
The current code ignores subdirectories in the suites tests path
that do not contain "task.yaml" files. However if there are files
inside the dir spread errors with:

```
error: open ...tests/lib.sh/task.yaml: not a directory
```

The attached code files this and the file is simpliy ignored.

Happy to add a spread test to it if that is something that looks
worthwhile to you.
