### PR TITLE
client.go: when using sudo, erase SUDO_{USER,UID,GID}

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -417,7 +417,7 @@ func (c *Client) sudo() string {
 	if c.config.User == "root" {
 		return ""
 	}
-	return "sudo -i "
+	return "sudo -i env -u SUDO_USER -u SUDO_UID -u SUDO_GID "
 }
 
 func getenv(name, defaultValue string) string {


### PR DESCRIPTION
This ensure the environment is consistent between the linode/qemu backend and the adhoc backend. Some applications behave differently when they find SUDO_USER (and friends) in the environment.
