### PR TITLE
nil reuse data for adhoc backends

### DIFF
--- a/spread/adhoc.go
+++ b/spread/adhoc.go
@@ -51,11 +51,7 @@ func (s *adhocServer) System() *System {
 }
 
 func (s *adhocServer) ReuseData() []byte {
-	data, err := yaml.Marshal(&s.d)
-	if err != nil {
-		panic(err)
-	}
-	return data
+	return nil
 }
 
 func (s *adhocServer) Discard() error {

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -577,12 +577,15 @@ Dial:
 		r.discardServer(server)
 		return nil
 	}
-	err = client.WriteFile("/.spread.yaml", server.ReuseData())
-	if err != nil {
-		printf("Discarding %s, cannot write reuse data: %s", server, err)
-		client.Close()
-		r.discardServer(server)
-		return nil
+	if reuseData := server.ReuseData(); reuseData != nil {
+		err = client.WriteFile("/.spread.yaml", reuseData)
+
+		if err != nil {
+			printf("Discarding %s, cannot write reuse data: %s", server, err)
+			client.Close()
+			r.discardServer(server)
+			return nil
+		}
 	}
 
 	printf("Connected to %s at %s.", server, server.Address())


### PR DESCRIPTION
This changeset deals with reuse data for adhoc backends, given that they are allocated externally reuse and regular connections are mostly the same. Also, if there's no reuse data these changes make sure that the file with the reuse data is not written.