### PR TITLE
With exporting PATH now we miss the preconfigured /snap/bin in it

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -329,7 +329,7 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; echo $stdin | grep -q -e \"$@\" || { echo \"error: pattern not found, got:\n$stdin\">&2; return 1; }; }\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
-	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n")
+	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")
 
 	for _, k := range env.Keys() {
 		v := env.Get(k)
@@ -695,7 +695,7 @@ func (s *localScript) run() (stdout, stderr []byte, err error) {
 	buf.WriteString("MATCH() { { set +xu; } 2> /dev/null; local stdin=$(cat); echo $stdin | grep -q -e \"$@\" || { echo \"error: pattern not found on stdin:\\n$output\">&2; return 1; }; }\n")
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
-	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n")
+	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")
 
 	for _, k := range s.env.Keys() {
 		v := s.env.Get(k)


### PR DESCRIPTION
/snap/bin would normally we added from the system the test is running
on but as we override PATH now we should better add it there as well.