### PR TITLE
show aborted tasks

### DIFF
--- a/spread/runner.go
+++ b/spread/runner.go
@@ -974,6 +974,7 @@ func (s *stats) log() {
 	printf("Successful tasks: %d", len(s.TaskDone))
 	printf("Aborted tasks: %d", len(s.TaskAbort))
 
+	logNames(printf, "Aborted tasks", s.TaskAbort, taskName)
 	logNames(printf, "Failed tasks", s.TaskError, taskName)
 	logNames(printf, "Failed task prepare", s.TaskPrepareError, taskName)
 	logNames(printf, "Failed task restore", s.TaskRestoreError, taskName)


### PR DESCRIPTION
Trivial branch that shows the aborted tasks. When looking at a snapd failure this morning I only saw "aborted tasks: 2" but it was tricky to find what exactly was aborted from the long snapd test log.