### PR TITLE
properly quote a variable in MATCH

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -327,7 +327,7 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	}
 	buf.WriteString(rc(false, "REBOOT() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<REBOOT>' || echo \"<REBOOT $1>\"; exit 213; }\n"))
 	buf.WriteString(rc(false, "ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n"))
-	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; echo $stdin | grep -q -E \"$@\" || { echo \"error: pattern not found, got:\n$stdin\">&2; return 1; }; }\n"))
+	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; echo \"$stdin\" | grep -q -E \"$@\" || { echo \"error: pattern not found, got:\n$stdin\">&2; return 1; }; }\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
 	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n")

--- a/tests/match/checks/main/task.yaml
+++ b/tests/match/checks/main/task.yaml
@@ -7,7 +7,7 @@ execute: |
     fi
 
     cat task.out
-    cat task.out | wc -l | grep 0
+    test "$(wc -l < task.out)" -eq 0
 
     cat task.err
     cat task.err | grep "^error: pattern not found, got:$"
@@ -17,9 +17,12 @@ execute: |
     echo -e "foo\nbar" | MATCH foo &> task.out
 
     cat task.out
-    cat task.out | wc -l | grep 0
+    test "$(wc -l < task.out)" -eq 0
 
     echo "Ensure it's using the extended regexp syntax."
     echo -e "foo" | MATCH "(foo|bar)"
+
+    echo "Ensure input can be multiline."
+    echo -e "foo\nbar\nbaz" | MATCH '^bar$'
 
     echo WORKS


### PR DESCRIPTION
We were missing quotes around a variable in MATCH, meaning you couldn't use `^` and `$` in a regexp wanting to match a multiline string.