### PR TITLE
fix incorrect match against variants

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -1084,6 +1084,9 @@ func matches(pattern string, strmaps ...strmap) ([]string, error) {
 	var matches []string
 	for _, strmap := range strmaps {
 		for _, name := range strmap.strings {
+			if strings.HasPrefix(name, "+") || strings.HasPrefix(name, "-") {
+				name = name[1:]
+			}
 			m, err := filepath.Match(pattern, name)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Sorry for this regression, variants use the `+` prefix and I did not catch this when doing the original patch. This diff fixes it and I ran the entire snapd suite without errors with this modification.