### PR TITLE
Supporting repeating of tasks via -repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,21 +519,14 @@ are aggregated and repeated for every task under them.
 
 <a name="reexecuting"/>
 
-## Reexecuting
+## Repeating runs
 
-Reproduce an error could be a very boring experience, and Spread has a way to
-simplify that process by reexecuting the tasks as many times is desired until
+Reproducing an error may be a very boring experience, and Spread has a way to
+simplify that process by reexecuting the tasks as many times as desired until
 the task fails.
 
-To do that there are two options `-retries`, and `-stop-on-fail` which are
-used to determine the number of time to reexecute a task and if those executions
-have to be stoped when the task has failed.
-
-The `-retries` option receives an integer which indicates the number of retries 
-to do, being 0 the default value, and -1 can be used to reexecute indefinitely.
-
-All the tasks listed to be executed will be reexercuted following the same
-conditions.
+To do that there is an option `-repeat` which receives an integer indicating 
+the number of reexecutions to do, being 0 the default value.
 
 
 <a name="passwords">

--- a/README.md
+++ b/README.md
@@ -522,17 +522,17 @@ are aggregated and repeated for every task under them.
 ## Reexecuting
 
 Reproduce an error could be a very boring experience, and Spread has a way to
-simplify that process by reexecuting the jobs as many times is desired until
-the jobs fails.
+simplify that process by reexecuting the tasks as many times is desired until
+the task fails.
 
 To do that there are two options `-retries`, and `-stop-on-fail` which are
-used to determine the number of time to reexecute a job and if those executions
-have to be stoped when the job has failed.
+used to determine the number of time to reexecute a task and if those executions
+have to be stoped when the task has failed.
 
 The `-retries` option receives an integer which indicates the number of retries 
 to do, being 0 the default value, and -1 can be used to reexecute indefinitely.
 
-All the jobs listed to be executed will be reexercuted following the same
+All the tasks listed to be executed will be reexercuted following the same
 conditions.
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Spread
 [Timeouts](#timeouts)  
 [Fast iterations with reuse](#reuse)  
 [Debugging](#debugging)  
-[Reexecuting](#reexecuting)
+[Repeating tasks](#repeating)
 [Passwords and usernames](#passwords)  
 [Including, excluding, and renaming files](#including)  
 [Selecting which tasks to run](#selecting)  
@@ -517,9 +517,9 @@ as a `debug-each` script at the project, backend, and suite levels, so they
 are aggregated and repeated for every task under them.
 
 
-<a name="reexecuting"/>
+<a name="repeating"/>
 
-## Repeating runs
+## Repeating tasks
 
 Reproducing an error may be a very boring experience, and Spread has a way to
 simplify that process by reexecuting the tasks as many times as desired until

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Spread
 [Timeouts](#timeouts)  
 [Fast iterations with reuse](#reuse)  
 [Debugging](#debugging)  
+[Reexecuting](#reexecuting)
 [Passwords and usernames](#passwords)  
 [Including, excluding, and renaming files](#including)  
 [Selecting which tasks to run](#selecting)  
@@ -514,6 +515,25 @@ debug: |
 In a similar way to prepare and restore scripts, these can also be defined
 as a `debug-each` script at the project, backend, and suite levels, so they
 are aggregated and repeated for every task under them.
+
+
+<a name="reexecuting"/>
+
+## Reexecuting
+
+Reproduce an error could be a very boring experience, and Spread has a way to
+simplify that process by reexecuting the jobs as many times is desired until
+the jobs fails.
+
+To do that there are two options `-retries`, and `-stop-on-fail` which are
+used to determine the number of time to reexecute a job and if those executions
+have to be stoped when the job has failed.
+
+The `-retries` option receives an integer which indicates the number of retries 
+to do, being 0 the default value, and -1 can be used to reexecute indefinitely.
+
+All the jobs listed to be executed will be reexercuted following the same
+conditions.
 
 
 <a name="passwords">

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -32,7 +32,7 @@ var (
 	discard     = flag.Bool("discard", false, "Discard reused servers without running")
 	residue     = flag.String("residue", "", "Where to store residual data from tasks")
 	seed        = flag.Int64("seed", 0, "Seed for job order permutation")
-	repeat      = flag.Int("repeat", 0, "The number of reexecutions for each task")
+	repeat      = flag.Int("repeat", 0, "Number of times to repeat each task")
 )
 
 func main() {

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -32,8 +32,8 @@ var (
 	discard     = flag.Bool("discard", false, "Discard reused servers without running")
 	residue     = flag.String("residue", "", "Where to store residual data from tasks")
 	seed        = flag.Int64("seed", 0, "Seed for job order permutation")
-	retries     = flag.Int("retries", 0, "The number of reexecutions for each job")
-	stopOnFail  = flag.Bool("stop-on-fail", false, "Stop the reexecuting the job when it fails")
+	retries     = flag.Int("retries", 0, "The number of reexecutions for each task")
+	stopOnFail  = flag.Bool("stop-on-fail", false, "Stop the reexecuting the task when it fails")
 )
 
 func main() {

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -32,8 +32,7 @@ var (
 	discard     = flag.Bool("discard", false, "Discard reused servers without running")
 	residue     = flag.String("residue", "", "Where to store residual data from tasks")
 	seed        = flag.Int64("seed", 0, "Seed for job order permutation")
-	retries     = flag.Int("retries", 0, "The number of reexecutions for each task")
-	stopOnFail  = flag.Bool("stop-on-fail", false, "Stop the reexecuting the task when it fails")
+	repeat      = flag.Int("repeat", 0, "The number of reexecutions for each task")
 )
 
 func main() {
@@ -94,8 +93,7 @@ func run() error {
 		Discard:     *discard,
 		Residue:     *residue,
 		Seed:        *seed,
-		Retries:     *retries,
-		StopOnFail:  *stopOnFail,
+		Repeat:      *repeat,
 	}
 
 	project, err := spread.Load(".")

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -32,6 +32,8 @@ var (
 	discard     = flag.Bool("discard", false, "Discard reused servers without running")
 	residue     = flag.String("residue", "", "Where to store residual data from tasks")
 	seed        = flag.Int64("seed", 0, "Seed for job order permutation")
+	retries     = flag.Int("retries", 0, "The number of reexecutions for each job")
+	stopOnFail  = flag.Bool("stop-on-fail", false, "Stop the reexecuting the job when it fails")
 )
 
 func main() {
@@ -92,6 +94,8 @@ func run() error {
 		Discard:     *discard,
 		Residue:     *residue,
 		Seed:        *seed,
+		Retries:     *retries,
+		StopOnFail:  *stopOnFail,
 	}
 
 	project, err := spread.Load(".")

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -33,6 +33,8 @@ type Options struct {
 	Discard     bool
 	Residue     string
 	Seed        int64
+	Retries     int
+	StopOnFail  bool
 }
 
 type Runner struct {
@@ -594,27 +596,35 @@ func (r *Runner) worker(backend *Backend, system *System, order []int) {
 		}
 
 		debug := job.Debug()
-		if r.options.Restore {
-			// Do not prepare or execute.
-		} else if !r.options.Restore && !r.run(client, job, preparing, job, job.Prepare(), debug, &abend) {
-			r.add(&stats.TaskPrepareError, job)
-			r.add(&stats.TaskAbort, job)
-			debug = ""
-		} else if !r.options.Restore && r.run(client, job, executing, job, job.Task.Execute, debug, &abend) {
-			r.add(&stats.TaskDone, job)
-		} else if !r.options.Restore {
-			r.add(&stats.TaskError, job)
-			debug = ""
-		}
-		if !abend && !r.options.Restore {
-			if err := r.fetchResidue(client, job); err != nil {
-				printf("Cannot fetch residue of %s: %v", job, err)
-				r.tomb.Killf("cannot fetch residue of %s: %v", job, err)
+		var retry = 0
+		var stopJob = false
+		for retry <= r.options.Retries && !stopJob {
+			if r.options.Restore {
+				// Do not prepare or execute.
+			} else if !r.options.Restore && !r.run(client, job, preparing, job, job.Prepare(), debug, &abend) {
+				r.add(&stats.TaskPrepareError, job)
+				r.add(&stats.TaskAbort, job)
+				debug = ""
+				stopJob = r.options.StopOnFail
+			} else if !r.options.Restore && r.run(client, job, executing, job, job.Task.Execute, debug, &abend) {
+				r.add(&stats.TaskDone, job)
+			} else if !r.options.Restore {
+				r.add(&stats.TaskError, job)
+				debug = ""
+				stopJob = r.options.StopOnFail
 			}
-		}
-		if !abend && !r.run(client, job, restoring, job, job.Restore(), debug, &abend) {
-			r.add(&stats.TaskRestoreError, job)
-			badProject = true
+			if !abend && !r.options.Restore {
+				if err := r.fetchResidue(client, job); err != nil {
+					printf("Cannot fetch residue of %s: %v", job, err)
+					r.tomb.Killf("cannot fetch residue of %s: %v", job, err)
+				}
+			}
+			if !abend && !r.run(client, job, restoring, job, job.Restore(), debug, &abend) {
+				r.add(&stats.TaskRestoreError, job)
+				badProject = true
+				stopJob = r.options.StopOnFail
+			}
+			retry += 1
 		}
 	}
 

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -597,7 +597,8 @@ func (r *Runner) worker(backend *Backend, system *System, order []int) {
 		debug := job.Debug()
 		for repeat := r.options.Repeat; repeat >= 0; repeat-- {
 			if r.options.Restore {
-				// Do not prepare or execute.
+				// Do not prepare or execute, and don't repeat.
+				repeat = -1
 			} else if !r.options.Restore && !r.run(client, job, preparing, job, job.Prepare(), debug, &abend) {
 				r.add(&stats.TaskPrepareError, job)
 				r.add(&stats.TaskAbort, job)
@@ -610,7 +611,7 @@ func (r *Runner) worker(backend *Backend, system *System, order []int) {
 				debug = ""
 				repeat = -1
 			}
-			if !abend && !r.options.Restore {
+			if !abend && !r.options.Restore && repeat == 0 {
 				if err := r.fetchResidue(client, job); err != nil {
 					printf("Cannot fetch residue of %s: %v", job, err)
 					r.tomb.Killf("cannot fetch residue of %s: %v", job, err)


### PR DESCRIPTION
This commit introduces a new mechanism to reexecute jobs reusing the
context.
This commit includes 2 new options:
-retries <int>: defines the number of times to retry any task to be
executed
-stop-on-fail: indicates if the retries have to be stopped once the task
fails.