### PR TITLE
Snap as classic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .spread-reuse.yaml
+*.snap
+*.tar.bz2
 cmd/spread/spread
 tests/cache/*
 parts

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: spread
+version: 2017.05.24
+summary: Convenient full-system test (task) distribution
+description: |
+    Spread is a plesant way distribute full-system integration tests and
+    similar tasks. A few simple and concrete concepts that are fun to play
+    with and fix the exact piece missing in the puzzle. It's not Jenkins,
+    it's not Travis, it's not a library, not a language, and it's not even
+    specific to testing. It's a simple way to express what to run and
+    where, what to do before and after it runs, and how to duplicate jobs
+    with minor variations without copy & paste.
+
+confinement: classic
+grade: stable
+
+apps:
+    spread:
+        command: bin/spread
+        plugs: [home, network, network-bind]
+
+parts:
+    spread:
+        plugin: go
+        go-packages:
+            - github.com/snapcore/spread/cmd/spread
+        go-importpath: github.com/snapcore/spread

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,3 +24,4 @@ parts:
         go-packages:
             - github.com/snapcore/spread/cmd/spread
         go-importpath: github.com/snapcore/spread
+

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strconv"
 
+	"path/filepath"
+
 	"golang.org/x/net/context"
 )
 
@@ -86,7 +88,15 @@ func (p *qemuProvider) Reuse(ctx context.Context, rsystem *ReuseSystem, system *
 }
 
 func systemPath(system *System) string {
-	return os.ExpandEnv("$HOME/.spread/qemu/" + system.Image + ".img")
+	basePath := os.Getenv("SPREAD_QEMU_PATH")
+	if basePath == "" {
+		if snapPath := os.Getenv("SNAP_USER_DATA"); len(snapPath) > 0 {
+			basePath = os.ExpandEnv(filepath.Join(snapPath, ".spread/qemu"))
+		} else {
+			basePath = "$HOME/.spread/qemu/"
+		}
+	}
+	return os.ExpandEnv(filepath.Join(basePath, system.Image+".img"))
 }
 
 func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, error) {


### PR DESCRIPTION
Added snap with classic confinement. Corrected Qemu paths to find the backend image, to fit snap or from sources installation, or even if provided other path using SPREAD_QEMU_PATH