### PR TITLE
Performance mode showing tasks output with timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,15 @@ To do that there is an option `-repeat` which receives an integer indicating
 the number of reexecutions to do, being 0 the default value.
 
 
+<a name="performance"/>
+
+## Show performance output
+
+To perform a performance analysis of the tasks executions, Spread is able to
+show detailed information about tasks output including timestamps. To do that
+there is an option `-perf` which by default is false.
+
+
 <a name="passwords">
 
 ## Passwords and usernames

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -33,6 +33,7 @@ var (
 	residue     = flag.String("residue", "", "Where to store residual data from tasks")
 	seed        = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat      = flag.Int("repeat", 0, "Number of times to repeat each task")
+	perf        = flag.Bool("perf", false, "Show tasks output with datetime")
 )
 
 func main() {
@@ -94,6 +95,7 @@ func run() error {
 		Residue:     *residue,
 		Seed:        *seed,
 		Repeat:      *repeat,
+		Perf:        *perf,
 	}
 
 	project, err := spread.Load(".")


### PR DESCRIPTION
This change is used to print tasks output with timestamps which give
detailed information when performance issues are being traced.