### PR TITLE
Fix error handling for readProject. (LP #1636657)

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -453,6 +453,9 @@ var (
 
 func Load(path string) (*Project, error) {
 	filename, data, err := readProject(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load project file from %s: %v", path, err)
+	}
 
 	project := &Project{}
 	err = yaml.Unmarshal(data, project)


### PR DESCRIPTION
This will provide the right error messages, instead of showing invalid
project name.