### PR TITLE
Add execution condition to suites and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Spread
 [Variants](#variants)  
 [Blacklisting and whitelisting](#blacklisting)  
 [Preparing and restoring](#preparing)  
-[Functions](#functions)
+[Conditions](#conditions)  
+[Functions](#functions)  
 [Rebooting](#rebooting)  
 [Timeouts](#timeouts)  
 [Fast iterations with reuse](#reuse)  
@@ -389,6 +390,26 @@ In addition to preparing and restoring scripts, `debug` and `debug-each`
 scripts may also be defined in the same places. These are only run when other
 scripts fail, and their purpose is to display further information which might
 be helpful when trying to understand what went wrong.
+
+<a name="conditions"/>
+
+## Conditions
+
+Tasks often are executed when some conditions are checked. In order to achieve 
+this, it is possible to define a script which will determine if task has to be 
+executed. The condition script is called before the task preparation and in case
+the result is not possitive the task is skipped.
+
+The condition can be defined at suite or task level, and it is evaluated for 
+indenpendently fo each task.
+
+This is an example to show how to define a condition for a test suite:
+
+suites:
+    examples/:
+        summary: Simple examples
+        condition: |
+            [ -d /path/to/dir ]
 
 
 <a name="functions"/>

--- a/spread/project.go
+++ b/spread/project.go
@@ -285,9 +285,10 @@ func (e *Environment) Replace(oldkey, newkey, value string) {
 }
 
 type Suite struct {
-	Summary  string
-	Systems  []string
-	Backends []string
+	Summary     string
+	Systems     []string
+	Backends    []string
+	Condition   string
 
 	Variants    []string
 	Environment *Environment
@@ -314,10 +315,11 @@ func (s *Suite) String() string { return "suite " + s.Name }
 type Task struct {
 	Suite string `yaml:"-"`
 
-	Summary  string
-	Details  string
-	Systems  []string
-	Backends []string
+	Summary    string
+	Details    string
+	Systems    []string
+	Backends   []string
+	Condition  string
 
 	Variants    []string
 	Environment *Environment
@@ -372,6 +374,10 @@ func (job *Job) StringFor(context interface{}) string {
 		return job.Name
 	}
 	panic(fmt.Errorf("job %s asked to stringify unrelated value: %v", job, context))
+}
+
+func (job *Job) Condition() string {
+	return join(job.Suite.Condition, job.Task.Condition)
 }
 
 func (job *Job) Prepare() string {
@@ -566,6 +572,7 @@ func Load(path string) (*Project, error) {
 		suite.Name = sname + "/"
 		suite.Path = filepath.Join(project.Path, sname)
 		suite.Summary = strings.TrimSpace(suite.Summary)
+		suite.Condition = strings.TrimSpace(suite.Condition)
 		suite.Prepare = strings.TrimSpace(suite.Prepare)
 		suite.Restore = strings.TrimSpace(suite.Restore)
 		suite.Debug = strings.TrimSpace(suite.Debug)
@@ -621,6 +628,7 @@ func Load(path string) (*Project, error) {
 			task.Name = suite.Name + tname
 			task.Path = filepath.Dir(tfilename)
 			task.Summary = strings.TrimSpace(task.Summary)
+			task.Condition = strings.TrimSpace(task.Condition)
 			task.Prepare = strings.TrimSpace(task.Prepare)
 			task.Restore = strings.TrimSpace(task.Restore)
 			task.Debug = strings.TrimSpace(task.Debug)

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -444,7 +444,7 @@ func (r *Runner) run(client *Client, job *Job, verb string, context interface{},
 		dir = filepath.Join(r.project.RemotePath, job.Task.Name)
 	}
 	if (r.options.Shell || r.options.ShellBefore) && verb == executing {
-	    printf("Starting shell instead of %s %s...", verb, job)
+		printf("Starting shell instead of %s %s...", verb, job)
 		err := client.Shell("", dir, r.shellEnv(job, job.Environment))
 		if err != nil {
 			printf("Error running debug shell: %v", err)
@@ -460,36 +460,36 @@ func (r *Runner) run(client *Client, job *Job, verb string, context interface{},
 	printft(start, endTime, "")
 
 	if verb == checking {
-	    if err != nil {
-	        logft(start, startTime, "%s %s...", strings.Title(skipping), contextStr)    
-	        return false
-	    }
-	    return true
+		if err != nil {
+			logft(start, startTime, "%s %s...", strings.Title(skipping), contextStr)    
+			return false
+		}
+		return true
 	}
 	if err != nil {
-	    // Use a different time so it has a different id on Travis, but keep
-	    // the original start time so the error message shows the task time.
-	    start = start.Add(1)
-	    printft(start, startTime|endTime|startFold|endFold, "Error %s %s : %v", verb, contextStr, err)
-	    if debug != "" {
-	        start = time.Now()
-	        output, err := client.Trace(debug, dir, job.Environment)
-	        if err != nil {
-	            printft(start, startTime|endTime|startFold|endFold, "Error debugging %s : %v", contextStr, err)
-	        } else if len(output) > 0 {
-	            printft(start, startTime|endTime|startFold|endFold, "Debug output for %s : %v", contextStr, outputErr(output, nil))
-	        }
-	    }
-	    if r.options.Debug || r.options.ShellAfter {
-	        printf("Starting shell to debug...")
-	        err = client.Shell("", dir, r.shellEnv(job, job.Environment))
-	        if err != nil {
-	            printf("Error running debug shell: %v", err)
-	        }
-	        printf("Continuing...")
-	    }
-	    *abend = r.options.Abend
-	    return false
+		// Use a different time so it has a different id on Travis, but keep
+		// the original start time so the error message shows the task time.
+		start = start.Add(1)
+		printft(start, startTime|endTime|startFold|endFold, "Error %s %s : %v", verb, contextStr, err)
+		if debug != "" {
+			start = time.Now()
+			output, err := client.Trace(debug, dir, job.Environment)
+			if err != nil {
+				printft(start, startTime|endTime|startFold|endFold, "Error debugging %s : %v", contextStr, err)
+			} else if len(output) > 0 {
+				printft(start, startTime|endTime|startFold|endFold, "Debug output for %s : %v", contextStr, outputErr(output, nil))
+			}
+		}
+		if r.options.Debug || r.options.ShellAfter {
+			printf("Starting shell to debug...")
+			err = client.Shell("", dir, r.shellEnv(job, job.Environment))
+			if err != nil {
+				printf("Error running debug shell: %v", err)
+			}
+			printf("Continuing...")
+		}
+		*abend = r.options.Abend
+		return false
 	}
 	if r.options.ShellAfter && verb == executing {
 		printf("Starting shell after %s %s...", verb, job)


### PR DESCRIPTION
This change introduces the concept of condition, which is an script that
is evaluated before running a test or suite and based on its results the
task is executed or skipped.
The idea of this condition is to avoid adding "if" in the prepare-
execute-restore to exit.
A clear example where it can be used is the test main/refresh-all in
snapd project. In that case the condition should be:

condition: |
    [ "$TRUST_TEST_KEYS" = "true" ]