### PR TITLE
client: use a different debug message on reboot reconnect delay

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -97,7 +97,7 @@ func (c *Client) dialOnReboot() error {
 		select {
 		case <-retry.C:
 		case <-relog.C:
-			printf("Reboot of %s is taking a while...", c.server)
+			printf("Reconnect after reboot of %s is taking a while...", c.server)
 		case <-timeout:
 			return fmt.Errorf("kill-timeout reached, cannot reconnect to %s after reboot: %v", c.server, err)
 		}


### PR DESCRIPTION
I have a case where I get a spread test that relies on rebooting that cannot reconnect. The interessting question is now if it hangs before or after the reboot. The delay message is the same so I would like to suggest a tiny change to make it easy to spot at what stage we are.