### PR TITLE
Fix LXD backend when run as a snap (Issue #11).

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,10 +16,12 @@ grade: stable
 apps:
     spread:
         command: bin/spread
-        plugs: [home, network, network-bind]
+        plugs: [home, network, network-bind, lxd]
 
 parts:
     spread:
         plugin: go
         go-packages:
             - github.com/snapcore/spread/cmd/spread
+        stage-packages:
+            - lxd-client


### PR DESCRIPTION
Snaps can't access binaries outside their shipped rootfs, so ship the lxc command
in the snap.

This requires that the user manually connect the lxd interface, but that's unavoidable.