### PR TITLE
Don't crash if suite is empty

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -559,6 +559,9 @@ func Load(path string) (*Project, error) {
 	orig := project.Suites
 	project.Suites = make(map[string]*Suite)
 	for sname, suite := range orig {
+		if suite == nil {
+			suite = &Suite{}
+		}
 		if !strings.HasSuffix(sname, "/") {
 			return nil, fmt.Errorf("invalid suite name (must end with /): %q", sname)
 		}


### PR DESCRIPTION
The unmarshaled suite can be nil in a following situation:

    project: demo
    path: /home/demo
    suites:
	tests/:

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>