### PR TITLE
Add support for project-wide measure-each stanza

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Spread
 [Fast iterations with reuse](#reuse)  
 [Debugging](#debugging)  
 [Repeating tasks](#repeating)
+[Measuring system deviation](#measuring)
 [Passwords and usernames](#passwords)  
 [Including, excluding, and renaming files](#including)  
 [Selecting which tasks to run](#selecting)  
@@ -516,6 +517,20 @@ In a similar way to prepare and restore scripts, these can also be defined
 as a `debug-each` script at the project, backend, and suite levels, so they
 are aggregated and repeated for every task under them.
 
+<a name="measuring"/>
+
+## Measuring
+
+Tests can modify the system in unexpected ways. Using project-wide
+`measure-each` stanza you can execute a command that can measure deviations of
+the test environment.
+
+As a simple advice, collect useful information that should be invariant (file
+list, package list, mount table, etc) and store that in a set of files. Those
+files should be (ideally) removed in project-wide prepare script.
+
+The measurement command is executed before preparing and after restoring each
+job.
 
 <a name="repeating"/>
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -30,6 +30,7 @@ type Project struct {
 	PrepareEach string `yaml:"prepare-each"`
 	RestoreEach string `yaml:"restore-each"`
 	DebugEach   string `yaml:"debug-each"`
+	MeasureEach string `yaml:"measure-each"`
 
 	Suites map[string]*Suite
 
@@ -487,6 +488,7 @@ func Load(path string) (*Project, error) {
 	project.PrepareEach = strings.TrimSpace(project.PrepareEach)
 	project.RestoreEach = strings.TrimSpace(project.RestoreEach)
 	project.DebugEach = strings.TrimSpace(project.DebugEach)
+	project.MeasureEach = strings.TrimSpace(project.MeasureEach)
 
 	if err := checkEnv(project, &project.Environment); err != nil {
 		return nil, err


### PR DESCRIPTION
The measurement feature allows to use a script to measure the testbed
(in some meaningful way) and raise a red flag (hopefully with a useful
error message) when something changes. This can be invaluable to look
for tests that don't clean up properly or change the system in some
unexpected way.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>