### PR TITLE
Add the resize of the partition on the googleStartupScript

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -157,6 +157,8 @@ echo root:%s | chpasswd
 sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
 
 pkill -o -HUP sshd || true
+growpart /dev/sda 1 || true
+resize2fs /dev/sda1 || true
 
 echo '` + googleReadyMarker + `' > /dev/ttyS2
 `


### PR DESCRIPTION
This is done because the resize of the partition is not done
automatically in all the systems such as fedora or centos.
This change implements the recomendation of google to make manually the
resize of the partition within the startup script.