### PR TITLE
add go1.6 compatibility

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -2,7 +2,6 @@ package spread
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +9,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	// used instead of just importing "context" for compatibility
+	// with go1.6 which is used in the xenial autopkgtests
+	"golang.org/x/net/context"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
@@ -98,7 +101,7 @@ func (c *Client) dialOnReboot(prevUptime time.Time) error {
 		}
 
 		uptimeDelta := currUptime.Sub(prevUptime)
-		if  uptimeDelta > uptimeChanged {
+		if uptimeDelta > uptimeChanged {
 			// Reboot done
 			return nil
 		}


### PR DESCRIPTION
Use "golang.org/x/net/context" instead of "context" so that we get
back go 1.6 compatibility. This should fix the issue that snapd
fails in the autopkgtest setup in ubuntu 16.04. There we try to
build spread from the branch and it fails because "context" is
only available in go1.7.

The other whitespace change happend automatically because `go fmt`
is part of my editor. But I can remove it if you prefer it in a separate PR/commit.