### PR TITLE
Adding preserve option for systems to keep the default image size

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -428,6 +428,18 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 		})
 	}
 
+	initializeParams := googleParams{}
+	if system.Preserve == true {
+		initializeParams = googleParams{
+			"sourceImage": sourceImage,
+		}
+	} else {
+		initializeParams = googleParams{
+			"sourceImage": sourceImage,
+			"diskSizeGb": storage,
+		}
+	}
+
 	params := googleParams{
 		"name":        name,
 		"machineType": "zones/" + p.gzone() + "/machineTypes/" + plan,
@@ -442,10 +454,7 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 			"autoDelete": "true",
 			"boot":       "true",
 			"type":       "PERSISTENT",
-			"initializeParams": googleParams{
-				"sourceImage": sourceImage,
-				"diskSizeGb": storage,
-			},
+			"initializeParams": initializeParams,
 		}},
 		"metadata": googleParams{
 			"items": []googleParams{{

--- a/spread/project.go
+++ b/spread/project.go
@@ -118,6 +118,7 @@ type System struct {
 	Username string
 	Password string
 	Workers  int
+	Preserve bool
 
 	Environment *Environment
 	Variants    []string


### PR DESCRIPTION
In case preserve option is true, then the system image will keep the default size, otherwise it will be set to 10 GB by default.