### PR TITLE
spread: do not panic if error message from google backend is empty

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -753,7 +753,11 @@ type googleError struct {
 
 func (r *googleResult) err() error {
 	for _, e := range r.Error.Errors {
-		return fmt.Errorf("%s", strings.ToLower(string(e.Message[0]))+e.Message[1:])
+		msg := "<no-message-provided>"
+		if e.Message != "" {
+			msg = strings.ToLower(string(e.Message[0])) + e.Message[1:]
+		}
+		return fmt.Errorf("(%s) %s: %s", e.Domain, e.Reason, msg)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix panic:
```
panic: runtime error: index out of range

goroutine 123 [running]:
github.com/snapcore/spread/spread.(*googleResult).err(0xc4215e6ff0, 0x8d, 0x200)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:756 +0x1e0
github.com/snapcore/spread/spread.(*googleProvider).dofl(0xc42010ecb0, 0x7c7ade, 0x3, 0xc420251800, 0x2c, 0x0, 0x0, 0x72d5a0, 0xc4221e0780, 0x0, ...)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:853 +0x883
github.com/snapcore/spread/spread.(*googleProvider).dozfl(0xc42010ecb0, 0x7c7ade, 0x3, 0xc421249210, 0x1b, 0x0, 0x0, 0x72d5a0, 0xc4221e0780, 0x0, ...)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:770 +0xef
github.com/snapcore/spread/spread.(*googleProvider).doz(0xc42010ecb0, 0x7c7ade, 0x3, 0xc421249210, 0x1b, 0x0, 0x0, 0x72d5a0, 0xc4221e0780, 0x1b, ...)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:766 +0x9d
github.com/snapcore/spread/spread.(*googleProvider).address(0xc42010ecb0, 0xc420120e00, 0xc4221c80c0, 0xc420120e00, 0x7c92ec, 0x9)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:201 +0xce
github.com/snapcore/spread/spread.(*googleProvider).createMachine(0xc42010ecb0, 0x813b40, 0xc4221c80c0, 0xc4201381e0, 0x0, 0x4298a9, 0xc400000008)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:482 +0x1adf
github.com/snapcore/spread/spread.(*googleProvider).Allocate(0xc42010ecb0, 0x813b40, 0xc4221c80c0, 0xc4201381e0, 0xc4203fe3e8, 0x44, 0x2, 0x7f8ce8b40066)
	/home/niemeyer/src/github.com/snapcore/spread/spread/google.go:137 +0x6e
github.com/snapcore/spread/spread.(*Runner).allocateServer(0xc42037bd40, 0xc42013a500, 0xc4201381e0, 0x0)
	/home/niemeyer/src/github.com/snapcore/spread/spread/runner.go:1373 +0x393
github.com/snapcore/spread/spread.(*Runner).client(0xc42037bd40, 0xc42013a500, 0xc4201381e0, 0x0)
	/home/niemeyer/src/github.com/snapcore/spread/spread/runner.go:1255 +0x72e
github.com/snapcore/spread/spread.(*Runner).worker(0xc42037bd40, 0xc42013a500, 0xc4201381e0, 0xc4223b9800, 0x84a, 0x84a)
	/home/niemeyer/src/github.com/snapcore/spread/spread/runner.go:1022 +0x8a
created by github.com/snapcore/spread/spread.(*Runner).loop
	/home/niemeyer/src/github.com/snapcore/spread/spread/runner.go:721 +0x732
```

Signed-off-by: Maciek Borzecki <maciek.borzecki@gmail.com>