### PR TITLE
client: fix dialOnReboot() if the remote does not reply

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -16,7 +16,7 @@ environment:
 backends:
     qemu:
         systems:
-            - ubuntu-16.04:
+            - ubuntu-16.04-64:
                 username: ubuntu
                 password: ubuntu
 

--- a/spread/client.go
+++ b/spread/client.go
@@ -84,9 +84,10 @@ func (c *Client) dialOnReboot(prevUptime time.Time) error {
 	waitConfig.Timeout = 5 * time.Second
 	uptimeChanged := 3 * time.Second
 
-	// close old session
-	c.sshc.Close()
 	for {
+		// Close old session
+		c.sshc.Close()
+
 		// Try to connect to the rebooting system, note that
 		// waitConfig is not well honored by golang, it is
 		// set to 5sec above but in reality it takes ~60sec

--- a/spread/client.go
+++ b/spread/client.go
@@ -84,38 +84,47 @@ func (c *Client) dialOnReboot(prevUptime time.Time) error {
 	waitConfig.Timeout = 5 * time.Second
 	uptimeChanged := 3 * time.Second
 
+	// close old session
+	c.sshc.Close()
 	for {
-		before := time.Now()
+		// Try to connect to the rebooting system, note that
+		// waitConfig is not well honored by golang, it is
+		// set to 5sec above but in reality it takes ~60sec
+		// before the code times out.
 		sshc, err := ssh.Dial("tcp", c.addr, &waitConfig)
-		if err != nil {
-			// It's gone.
-			continue
+		if err == nil {
+			// once successfully connected, check uptime to
+			// see if the reboot actually happend
+			c.sshc = sshc
+			currUptime, err := c.getUptime()
+			if err == nil {
+				uptimeDelta := currUptime.Sub(prevUptime)
+				if uptimeDelta > uptimeChanged {
+					// Reboot done
+					return nil
+				}
+			}
 		}
 
-		c.sshc.Close()
-		c.sshc = sshc
-		currUptime, err := c.getUptime()
-		if err != nil {
-			// Not available uptime yet
-			continue
-		}
-
-		uptimeDelta := currUptime.Sub(prevUptime)
-		if uptimeDelta > uptimeChanged {
-			// Reboot done
-			return nil
-		}
-		// Dial was observed not respecting the timeout by a long shot. Enforce it.
-		if time.Now().After(before.Add(waitConfig.Timeout)) {
-			break
-		}
-
+		// Use multiple selects to ensure that the channels get
+		// checked in the right order. If a single select is used
+		// and all channels have data golang will pick a random
+		// channel. This means that on timeout there is a 1/2 chance
+		// that there is also a retry and ssh.Dial() is run again
+		// which needs to timeout first before the channels are
+		// checked again.
 		select {
-		case <-retry.C:
-		case <-relog.C:
-			printf("Reboot on %s is taking a while...", c.job)
 		case <-timeout:
 			return fmt.Errorf("kill-timeout reached after %s reboot request", c.job)
+		default:
+		}
+		select {
+		case <-relog.C:
+			printf("Reboot on %s is taking a while...", c.job)
+		default:
+		}
+		select {
+		case <-retry.C:
 		}
 	}
 
@@ -289,7 +298,6 @@ func (c *Client) run(script string, dir string, env *Environment, mode outputMod
 			return nil, err
 		}
 		c.Run("reboot", "", nil)
-		time.Sleep(3 * time.Second)
 
 		if err := c.dialOnReboot(uptime); err != nil {
 			return nil, err


### PR DESCRIPTION
The PR#53 broke the timeout handling in dialOnReboot(). The
current code has some problems, especially when the target
does not survive the reboot (e.g. no working network after
the reboot):

- it will try to ssh.Dial() the target and never timeouts
- it will try to get uptime and on error retry forever
- ssh.Dial() is really doing the 5s timeout, on my system its
  more like 60s
- This means that the timeout, relog and retry channel all
  can have data in which case golang picks a random channel.
- This means on timeout in the worst case there is only a 1/3
  chance that the timeout channel is handled which may lead
  to much longer kill-timeouts (because ssh.Dial() takes ~60sec
  for me).

I would love to write a test for this, I think we need to mock
ssh.Dial() for this particular test and ideally getUptime as
well. I will do a followup with this as it will be slightly
more involved.