### PR TITLE
spread: warn if MATCH exists with an unknown status

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -361,7 +361,7 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	}
 	buf.WriteString(rc(false, "REBOOT() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<REBOOT>' || echo \"<REBOOT $1>\"; exit 213; }\n"))
 	buf.WriteString(rc(false, "ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n"))
-	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; echo \"$stdin\" | grep -q -E \"$@\" || { echo \"error: pattern not found, got:\n$stdin\">&2; return 1; }; }\n"))
+	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; echo \"$stdin\" | grep -q -E \"$@\" || { res=$?; echo \"error: pattern not found, got:\n$stdin\">&2; if [ $res != 1 ]; then echo \"unexpected exit status: $res\"; fi; return 1; }; }\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
 	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")


### PR DESCRIPTION
We saw some obscure MATCH failures when running spread tests against
snapd. It turns out the spread test is failing because of SIGPIPE
which is triggered by us using "-o pipefail". To make it easier
to find these kinds of issues print a warning in MATCH when an
exit-code != 1 is returned (this is the exit code used when no
match is found by grep).