### PR TITLE
Define storage at system level

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -426,12 +426,11 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 	diskParams := googleParams{
 		"sourceImage": sourceImage,
 	}
-	if system.Storage == 0 && p.backend.Storage == 0 {
+
+	if system.Storage == 0 {
 		diskParams["diskSizeGb"] = 10
 	} else if system.Storage > 0 {
 		diskParams["diskSizeGb"] = int(system.Storage / gb)
-	} else if p.backend.Storage > 0 {
-		diskParams["diskSizeGb"] = int(p.backend.Storage / gb)
 	}
 
 	params := googleParams{

--- a/spread/google.go
+++ b/spread/google.go
@@ -426,8 +426,10 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 	diskParams := googleParams{
 		"sourceImage": sourceImage,
 	}
-	if p.backend.Storage == 0 {
+	if system.Storage == 0 && p.backend.Storage == 0 {
 		diskParams["diskSizeGb"] = 10
+	} else if system.Storage > 0 {
+		diskParams["diskSizeGb"] = int(system.Storage / gb)
 	} else if p.backend.Storage > 0 {
 		diskParams["diskSizeGb"] = int(p.backend.Storage / gb)
 	}

--- a/spread/linode.go
+++ b/spread/linode.go
@@ -537,7 +537,9 @@ func (p *linodeProvider) createDisk(s *linodeServer, system *System) (root, swap
 	}
 
 	storage := 10000
-	if p.backend.Storage > 0 {
+	if system.Storage > 0 {
+		storage = int(system.Storage / mb)
+	} else if p.backend.Storage > 0 {
 		storage = int(p.backend.Storage / mb)
 	}
 

--- a/spread/linode.go
+++ b/spread/linode.go
@@ -539,8 +539,6 @@ func (p *linodeProvider) createDisk(s *linodeServer, system *System) (root, swap
 	storage := 10000
 	if system.Storage > 0 {
 		storage = int(system.Storage / mb)
-	} else if p.backend.Storage > 0 {
-		storage = int(p.backend.Storage / mb)
 	}
 
 	// Smallest disk is 30720MB. (10000+240)*3 == 30720,

--- a/spread/project.go
+++ b/spread/project.go
@@ -544,6 +544,9 @@ func Load(path string) (*Project, error) {
 			if system.Workers == 0 {
 				system.Workers = 1
 			}
+			if system.Storage == 0 {
+				system.Storage = backend.Storage
+			}
 			if err := checkEnv(system, &system.Environment); err != nil {
 				return nil, err
 			}

--- a/spread/project.go
+++ b/spread/project.go
@@ -119,6 +119,9 @@ type System struct {
 	Password string
 	Workers  int
 
+	// Only for Linode and Google so far.
+	Storage  Size
+
 	Environment *Environment
 	Variants    []string
 

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -881,6 +881,10 @@ func (r *Runner) allocateServer(backend *Backend, system *System) *Client {
 Allocate:
 	for {
 		lerr := err
+
+		if system.Storage == 0 {
+			system.Storage = backend.Storage
+		}
 		server, err = r.providers[backend.Name].Allocate(r.tomb.Context(nil), system)
 		if err == nil {
 			break

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -881,10 +881,6 @@ func (r *Runner) allocateServer(backend *Backend, system *System) *Client {
 Allocate:
 	for {
 		lerr := err
-
-		if system.Storage == 0 {
-			system.Storage = backend.Storage
-		}
 		server, err = r.providers[backend.Name].Allocate(r.tomb.Context(nil), system)
 		if err == nil {
 			break


### PR DESCRIPTION
This is to be able to set the preserve-size option for each storage independently.

Currently for snpad test suite we are using "storage: preserve-size" at backend level but it is forcing all the systems to preserve the storage size even when it is not needed, which could produce errors testing images with are 1 or 3 GB of storage such as some imported images from other projects. 

This is an example of the error that this is causing: https://paste.ubuntu.com/p/HJcSgvBp4b/
It is happening installing tests dependencies on ubuntu-16.04-32 on spread-images project.