### PR TITLE
spread: run MATCH in a subshell

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -363,7 +363,9 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	buf.WriteString(rc(false, "ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n"))
 	// We are not using pipes here, see:
 	//  https://github.com/snapcore/spread/pull/64
-	buf.WriteString(rc(true, "MATCH() { { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; grep -q -E \"$@\" <<< \"$stdin\" || { res=$?; echo \"grep error: pattern not found, got:\n$stdin\">&2; if [ $res != 1 ]; then echo \"unexpected grep exit status: $res\"; fi; return 1; }; }\n"))
+	// We also run it in a subshell, see
+	//  https://github.com/snapcore/spread/pull/67
+	buf.WriteString(rc(true, "MATCH() ( { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; grep -q -E \"$@\" <<< \"$stdin\" || { res=$?; echo \"grep error: pattern not found, got:\n$stdin\">&2; if [ $res != 1 ]; then echo \"unexpected grep exit status: $res\"; fi; return 1; }; )\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
 	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")


### PR DESCRIPTION
We ran into a confusing error when using MATCH in one of our snapd
tests. It runs out the issue can be reproduced with:
```
MATCH () {
    {
        set +ux
    } 2> /dev/null;
    return 0
}
MATCH foo <<< foo
test 1 -eq 2
```
When this is used, the output is:
```
$ bash -eux reproducer.sh
+ MATCH foo
```
I.e. the test line is not displayed.

It turns out the reason is that the MATCH function uses "set +ux"
which turns off the traces globally. When MATCH is used in a
pipe (e.g. "echo foo | MATCH foo") then MATCH is run in a
subshell and the turning off is not criticial. However when
using with here strings for file redirects and no subshell
is used turning off trace globally is an issue. The fix is
simply to run MATCH always in a subshell.