### PR TITLE
spread: allow delta format after plain (but not viceversa).

### DIFF
--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -1,0 +1,9 @@
+package spread
+
+func Strmap(context string, strings []string) strmap {
+	return strmap{context: stringer(context), strings: strings}
+}
+
+var (
+	Evalstr = evalstr
+)

--- a/spread/project.go
+++ b/spread/project.go
@@ -1184,8 +1184,7 @@ func matches(pattern string, strmaps ...strmap) ([]string, error) {
 func evalstr(what string, strmaps ...strmap) ([]string, error) {
 	final := make(map[string]bool)
 	for i, strmap := range strmaps {
-		delta := 0
-		plain := 0
+		hadDelta := false
 		for j, name := range strmap.strings {
 			add := strings.HasPrefix(name, "+")
 			remove := strings.HasPrefix(name, "-")
@@ -1194,12 +1193,9 @@ func evalstr(what string, strmaps ...strmap) ([]string, error) {
 				if i == 0 {
 					return nil, fmt.Errorf("%s specifies %s in delta format", strmap.context, what)
 				}
-				delta++
-			} else {
-				plain++
-			}
-			if delta > 0 && plain > 0 {
-				return nil, fmt.Errorf("%s specifies %s both in delta and plain format", strmap.context, what)
+				hadDelta = true
+			} else if hadDelta {
+				return nil, fmt.Errorf("%s specifies %s using plain format after delta", strmap.context, what)
 			}
 			matches, err := matches(name, strmaps[:i+1]...)
 			if err != nil {

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -1,6 +1,7 @@
 package spread_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/snapcore/spread/spread"
@@ -51,5 +52,82 @@ func (s *FilterSuite) TestFilter(c *C) {
 		f, err := spread.NewFilter([]string{s})
 		c.Assert(err, IsNil)
 		c.Assert(f.Pass(job), Equals, false, Commentf("Filter: %q", s))
+	}
+}
+
+func (s *FilterSuite) TestEvalstr(c *C) {
+	type goodTable struct {
+		desc                   string
+		root, sub1, sub2, want []string
+	}
+	for _, t := range []goodTable{
+		{
+			desc: "all absolute",
+			root: []string{"1", "2"},
+			sub1: []string{"1-1", "1-2"},
+			sub2: []string{"2-1", "2-2"},
+			want: []string{"2-1", "2-2"},
+		}, {
+			desc: "leaf relative",
+			root: []string{"1", "2"},
+			sub1: []string{"1-1", "1-2"},
+			sub2: []string{"+2-1", "-1-2"},
+			want: []string{"1-1", "2-1"},
+		}, {
+			desc: "most relative",
+			root: []string{"1", "2"},
+			sub1: []string{"+1-1", "+1-2", "-2"},
+			sub2: []string{"+2-1", "-1-2"},
+			want: []string{"1", "1-1", "2-1"},
+		}, {
+			desc: "leaf absolute",
+			root: []string{"1", "2"},
+			sub1: []string{"-2", "+1-1"},
+			sub2: []string{"2-1", "2-2"},
+			want: []string{"2-1", "2-2"},
+		}, {
+			desc: "leaf empty",
+			root: []string{"1", "2"},
+			sub1: []string{"1-1", "1-2"},
+			sub2: []string{},
+			want: []string{"1-1", "1-2"},
+		}, {
+			desc: "leaf glob",
+			root: []string{"1", "2"},
+			sub1: []string{"1-1", "1-2"},
+			sub2: []string{"*"},
+			want: []string{"*", "1", "1-1", "1-2", "2"}, // XXX: is this expected
+		}, {
+			desc: "mixed absolute-relative",
+			root: []string{"1-1", "1-2", "1-3"},
+			sub1: []string{"+2-1", "+2-2", "+2-3"},
+			sub2: []string{"1-*", "-*-3"},
+			want: []string{"1-*", "1-1", "1-2"}, // interesting that the glob isn't pruned
+		},
+	} {
+		root := spread.Strmap("root", t.root)
+		sub1 := spread.Strmap("sub1", t.sub1)
+		sub2 := spread.Strmap("sub2", t.sub2)
+
+		strs, err := spread.Evalstr(t.desc, root, sub1, sub2)
+		c.Check(err, IsNil, Commentf("%s", t.desc))
+		sort.Strings(strs)
+		c.Check(strs, DeepEquals, t.want, Commentf("%s", t.desc))
+	}
+
+	type badTable struct {
+		desc string
+		root []string
+		leaf []string
+		want string
+	}
+
+	for _, t := range []badTable{
+		{desc: "delta root[0] (impossible)", root: []string{"-0"}, want: "root specifies attr in delta format"},
+		{desc: "delta root[1] (unnecessary)", root: []string{"0", "+1"}, want: "root specifies attr in delta format"},
+		{desc: "bad leaf mix", leaf: []string{"0", "+1", "2"}, want: "leaf specifies attr using plain format after delta"},
+	} {
+		_, err := spread.Evalstr("attr", spread.Strmap("root", t.root), spread.Strmap("leaf", t.leaf))
+		c.Check(err, ErrorMatches, t.want)
 	}
 }


### PR DESCRIPTION
This allows writing something like

    systems: [ubuntu-*, -ubuntu-14*]

which is much shorter and future-proof than what's allowed with the
stricter never-mix-plain-and-delta rule.

Also, adds a unit test for evalstr.