### PR TITLE
Manage pagination retrieving images from google backend

### DIFF
--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -1,0 +1,19 @@
+package spread
+
+import (
+	"net/http"
+)
+
+func NewGoogleProviderForTesting(mockApiURL string, p *Project, b *Backend, o *Options) *googleProvider {
+	provider := Google(p, b, o)
+	ggl := provider.(*googleProvider)
+	ggl.apiURL = mockApiURL
+	ggl.keyChecked = true
+	ggl.client = &http.Client{}
+
+	return ggl
+}
+
+func (p *googleProvider) ProjectImages(project string) ([]googleImage, error) {
+	return p.projectImages(project)
+}

--- a/spread/google.go
+++ b/spread/google.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -369,7 +370,11 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 	var nextPageToken string
 	for {
 		var result googleImageListResult
-		err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?orderBy=creationTimestamp+desc&pageToken="+nextPageToken, nil, &result, noPathPrefix)
+		v := url.Values{
+			"orderBy":   {"creationTimestamp+desc"},
+			"pageToken": {nextPageToken},
+		}
+		err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?"+v.Encode(), nil, &result, noPathPrefix)
 		nextPageToken = result.NextPageToken
 		if err != nil {
 			return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}

--- a/spread/google.go
+++ b/spread/google.go
@@ -336,12 +336,12 @@ type googleImagesCache struct {
 
 type googleImageListResult struct {
 	Items []struct {
-		Description string
-		Status      string
-		Name        string
-		Family      string
+		Description	string
+		Status		string
+		Name		string
+		Family		string
 	}
-	NextPageToken 	string
+	NextPageToken	string
 }
 
 func (p *googleProvider) projectImages(project string) ([]googleImage, error) {

--- a/spread/google.go
+++ b/spread/google.go
@@ -371,8 +371,6 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 		var result googleImageListResult
 		err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?orderBy=creationTimestamp+desc&pageToken="+nextPageToken, nil, &result, noPathPrefix)
 		nextPageToken = result.NextPageToken
-		if err == googleNotFound {
-		}
 		if err != nil {
 			return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}
 		}

--- a/spread/google.go
+++ b/spread/google.go
@@ -334,6 +334,16 @@ type googleImagesCache struct {
 	err    error
 }
 
+type googleImageListResult struct {
+	Items []struct {
+		Description string
+		Status      string
+		Name        string
+		Family      string
+	}
+	NextPageToken 	string
+}
+
 func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 	p.mu.Lock()
 	cache, ok := p.imagesCache[project]
@@ -350,32 +360,36 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 		return cache.images, cache.err
 	}
 
-	var result struct {
-		Items []struct {
-			Description string
-			Status      string
-			Name        string
-			Family      string
+	var results []googleImageListResult
+	var nextPageToken string
+	for {
+		var result googleImageListResult
+		err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?orderBy=creationTimestamp+desc&pageToken="+nextPageToken, nil, &result, noPathPrefix)
+		nextPageToken = result.NextPageToken
+		if err == googleNotFound {
 		}
-	}
+		if err != nil {
+			return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}
+		}
+		results = append(results, result)
 
-	err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?orderBy=creationTimestamp+desc", nil, &result, noPathPrefix)
-	if err == googleNotFound {
-	}
-	if err != nil {
-		return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}
-	}
+		if nextPageToken == "" {
+			for _, element := range results {
+				for _, item := range element.Items {
+					cache.images = append(cache.images, googleImage{
+						Project: project,
+						Name:    item.Name,
+						Family:  item.Family,
+						Terms:   toTerms(item.Description),
+					})
+				}
+			}
+			return cache.images, err
+		}
 
-	for _, item := range result.Items {
-		cache.images = append(cache.images, googleImage{
-			Project: project,
-			Name:    item.Name,
-			Family:  item.Family,
-			Terms:   toTerms(item.Description),
-		})
 	}
+	return cache.images, nil
 
-	return cache.images, err
 }
 
 func (p *googleProvider) createMachine(ctx context.Context, system *System) (*googleServer, error) {

--- a/spread/google.go
+++ b/spread/google.go
@@ -366,7 +366,7 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 		return cache.images, cache.err
 	}
 
-	var results []googleImageListResult
+	var results []*googleImageListResult
 	var nextPageToken string
 	for {
 		var result googleImageListResult
@@ -379,7 +379,7 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 		if err != nil {
 			return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}
 		}
-		results = append(results, result)
+		results = append(results, &result)
 
 		if nextPageToken == "" {
 			break

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -1,0 +1,78 @@
+package spread_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/snapcore/spread/spread"
+
+	. "gopkg.in/check.v1"
+)
+
+type googleSuite struct{}
+
+var _ = Suite(&googleSuite{})
+
+func (s *googleSuite) TestPagination(c *C) {
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.ParseForm(), IsNil)
+			c.Check(r.Form.Get("pageToken"), Equals, "")
+			w.Write([]byte(`
+                {
+                    "items": [{"status":"READY","name":"ubuntu-1910-64-v20190826", "description":"ubuntu-19.10-64"}, {"status":"READY","name":"ubuntu-1904-64-v20190726", "description":"ubuntu-19.04-64"}],
+                    "nextpagetoken": "token-1"
+                }
+                `))
+		case 1:
+			c.Check(r.ParseForm(), IsNil)
+			c.Check(r.Form.Get("pageToken"), Equals, "token-1")
+			w.Write([]byte(`
+                {
+                    "items": [{"status":"READY","name":"opensuse-leap-42-3-v20190227", "description":"opensuse-leap-42-3-64"}, {"status":"READY","name":"debian-9-v20190901", "description":"debian-9-64"}],
+                    "nextpagetoken": "token-2"
+                }
+                `))
+		case 2:
+			c.Check(r.ParseForm(), IsNil)
+			c.Check(r.Form.Get("pageToken"), Equals, "token-2")
+			w.Write([]byte(`
+                {
+                    "items": [{"status":"READY","name":"fedora-28-64-v20181210", "description":"fedora-28-64"}],
+                    "nextpagetoken": ""
+                }
+                `))
+		}
+		n++
+	}))
+	defer mockServer.Close()
+
+	g := spread.NewGoogleProviderForTesting(mockServer.URL, nil, nil, nil)
+	c.Assert(g, NotNil)
+
+	images, err := g.ProjectImages("snapd")
+	c.Assert(err, IsNil)
+	c.Check(images, HasLen, 5)
+	i := 0
+	c.Check(images[i].Project, Equals, "snapd")
+	c.Check(images[i].Name, Equals, "ubuntu-1910-64-v20190826")
+	c.Check(images[i].Terms, DeepEquals, []string{"ubuntu", "19.10", "64"})
+	i++
+	c.Check(images[i].Project, Equals, "snapd")
+	c.Check(images[i].Name, Equals, "ubuntu-1904-64-v20190726")
+	c.Check(images[i].Terms, DeepEquals, []string{"ubuntu", "19.04", "64"})
+	i++
+	c.Check(images[i].Project, Equals, "snapd")
+	c.Check(images[i].Name, Equals, "opensuse-leap-42-3-v20190227")
+	c.Check(images[i].Terms, DeepEquals, []string{"opensuse", "leap", "42", "3", "64"})
+	i++
+	c.Check(images[i].Project, Equals, "snapd")
+	c.Check(images[i].Name, Equals, "debian-9-v20190901")
+	c.Check(images[i].Terms, DeepEquals, []string{"debian", "9", "64"})
+	i++
+	c.Check(images[i].Project, Equals, "snapd")
+	c.Check(images[i].Name, Equals, "fedora-28-64-v20181210")
+	c.Check(images[i].Terms, DeepEquals, []string{"fedora", "28", "64"})
+}

--- a/spread/google_test.go
+++ b/spread/google_test.go
@@ -54,6 +54,9 @@ func (s *googleSuite) TestPagination(c *C) {
 
 	images, err := g.ProjectImages("snapd")
 	c.Assert(err, IsNil)
+	// XXX: a `c.Check(images, DeepEquals, []spread.googleImage{...}`
+	// would be nice here but "googleImage" is not exported so we can't
+	// access it here. So we test a bit more indirect.
 	c.Check(images, HasLen, 5)
 	i := 0
 	c.Check(images[i].Project, Equals, "snapd")


### PR DESCRIPTION
Currently we are failing to get the fedora base image because it is in the second page of images retrieved by google. 

See spread output: 

spread google:fedora-28-64-base:tasks/google/update-fedora-28-64
2018-09-17 06:54:44 Project content is packed for delivery (112.64KB).
2018-09-17 06:54:44 If killed, discard servers with: spread -reuse-pid=27395 -discard
2018-09-17 06:54:44 Allocating google:fedora-28-64-base...
2018-09-17 06:54:44 Cannot allocate google:fedora-28-64-base: cannot find any Google image matching "fedora-28-64-base" on project "computeengine"
2018-09-17 06:54:44 Successful tasks: 0
2018-09-17 06:54:44 Aborted tasks: 1
error: unsuccessful run