### PR TITLE
Reboot on backgraound to avoid spread wait for long time

### DIFF
--- a/spread/client.go
+++ b/spread/client.go
@@ -296,7 +296,7 @@ func (c *Client) run(script string, dir string, env *Environment, mode outputMod
 		if err != nil {
 			return nil, err
 		}
-		c.Run("reboot", "", nil)
+		c.Run("reboot -f >/dev/null &", "", nil)
 
 		if err := c.dialOnReboot(uptime); err != nil {
 			return nil, err


### PR DESCRIPTION
This is to avoid this messages showing the output still empty when the
reboot was already done:

2018-11-05 14:48:35 Rebooting on nov051744-506863
(google:debian-9-64-base:tasks/google/update-debian-9) as requested...
2018-11-05 14:48:35 Getting uptime
2018-11-05 14:48:35 Uptime calculated
2018-11-05 14:48:35 Running reboot command
2018-11-05 14:53:36 WARNING: nov051744-506863
(google:debian-9-64-base:tasks/google/update-debian-9) running late.
Output still empty.
2018-11-05 14:58:36 WARNING: nov051744-506863
(google:debian-9-64-base:tasks/google/update-debian-9) running late.
Output still empty.

It can be reproduced easy on debian-9 where the reboot is done very fast
(~8sec).

With this chage the reboot is done on backgrand, and the ssh always
return. Then the uptime is compared to make sure the rebook was properly
done.