### PR TITLE
New -workers option used to define the number of workers by system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Spread
 [Fast iterations with reuse](#reuse)  
 [Debugging](#debugging)  
 [Repeating tasks](#repeating)
+[Define number of Workers](#workers)
 [Passwords and usernames](#passwords)  
 [Including, excluding, and renaming files](#including)  
 [Selecting which tasks to run](#selecting)  
@@ -560,6 +561,16 @@ the task fails.
 To do that there is an option `-repeat` which receives an integer indicating 
 the number of reexecutions to do, being 0 the default value.
 
+<a name="workers"/>
+
+## Define number of Workers
+
+The number of workers can be set as part of the spread.yaml file and also by
+using the `-workers` option, which receives an integer indicating
+the number of workers used by all the systems selected for the run.
+
+In case the `-workers` option is not used, the number of workers used is the
+provided for the system in the spread.yaml which is 1 by default.
 
 <a name="passwords">
 

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -34,6 +34,7 @@ var (
 	seed           = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat         = flag.Int("repeat", 0, "Number of times to repeat each task")
 	garbageCollect = flag.Bool("gc", false, "Garbage collect backend resources when possible")
+	workers        = flag.Int("workers", 0, "Number of workers to use on each system")
 )
 
 func main() {
@@ -96,6 +97,7 @@ func run() error {
 		Seed:           *seed,
 		Repeat:         *repeat,
 		GarbageCollect: *garbageCollect,
+		Workers:        *workers,
 	}
 
 	project, err := spread.Load(".")

--- a/spread/project.go
+++ b/spread/project.go
@@ -851,6 +851,16 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 		return nil, fmt.Errorf("remote project path must be absolute and not /: %s", p.RemotePath)
 	}
 
+	// In case the number of workers set in the options is bigger than 0,
+	// update all the systems with the numbers set in the options
+	if options.Workers > 0 {
+		for _, backend := range p.Backends {
+			for _, system := range backend.Systems {
+				system.Workers = options.Workers
+			}
+		}
+	}
+
 	for _, suite := range p.Suites {
 		senv := envmap{suite, suite.Environment}
 		sevr := strmap{suite, evars(suite.Environment, "+")}

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -36,6 +36,7 @@ type Options struct {
 	Seed           int64
 	Repeat         int
 	GarbageCollect bool
+	Workers        int
 }
 
 type Runner struct {


### PR DESCRIPTION
The number of workers can be set as part of the spread.yaml file and
also by using the `-workers` option, which receives an integer
indicating the number of workers used by all the systems selected for
the run.

In case the `-workers` option is not used, the number of workers used is
the provided for the system in the spread.yaml which is 1 by default.