### PR TITLE
Introducing the tag for the test which allow to filter tests to execute

### DIFF
--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -33,7 +33,9 @@ var (
 	residue        = flag.String("residue", "", "Where to store residual data from tasks")
 	seed           = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat         = flag.Int("repeat", 0, "Number of times to repeat each task")
+	tag            = flag.String("tag", "", "Filter tests which match with the tag specified")
 	garbageCollect = flag.Bool("gc", false, "Garbage collect backend resources when possible")
+
 )
 
 func main() {
@@ -95,6 +97,7 @@ func run() error {
 		Residue:        *residue,
 		Seed:           *seed,
 		Repeat:         *repeat,
+		Tag:            *tag,
 		GarbageCollect: *garbageCollect,
 	}
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -349,6 +349,7 @@ type Task struct {
 
 	Priority OptionalInt
 	Manual   bool
+	Tags     []string
 }
 
 func (t *Task) String() string { return t.Name }
@@ -984,6 +985,19 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 		}
 		if !manualTasks && job.Task.Manual {
 			continue
+		}
+
+		// Check the tag in the jon in case a tag is specified in the options
+		if options.Tag != "" {
+			tagMatch := false
+			for tag := range job.Task.Tags {
+				if options.Tag == job.Task.Tags[tag] {
+					tagMatch = true
+				}
+			}
+			if !tagMatch {
+				continue
+			}
 		}
 		jobs = append(jobs, job)
 		backends[job.Backend.Name] = true

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -35,6 +35,7 @@ type Options struct {
 	Residue        string
 	Seed           int64
 	Repeat         int
+	Tag            string
 	GarbageCollect bool
 }
 

--- a/tests/tag/checks/test-a/task.yaml
+++ b/tests/tag/checks/test-a/task.yaml
@@ -1,0 +1,6 @@
+summary: Test the tag option
+
+tags: [tag-a]
+
+execute: |
+    echo WORKS

--- a/tests/tag/checks/test-b/task.yaml
+++ b/tests/tag/checks/test-b/task.yaml
@@ -1,0 +1,6 @@
+summary: Test the tag option
+
+tags: [tag-a, tag-b]
+
+execute: |
+    echo WORKS

--- a/tests/tag/checks/test-c/task.yaml
+++ b/tests/tag/checks/test-c/task.yaml
@@ -1,0 +1,4 @@
+summary: Test the tag option
+
+execute: |
+    echo WORKS

--- a/tests/tag/spread.yaml
+++ b/tests/tag/spread.yaml
@@ -1,0 +1,14 @@
+project: spread
+
+backends:
+    lxd:
+        systems:
+            - ubuntu-16.04
+
+path: /home/test
+
+suites:
+    checks/: 
+        summary: Verification tasks.
+
+# vim:ts=4:sw=4:et

--- a/tests/tag/task.yaml
+++ b/tests/tag/task.yaml
@@ -1,0 +1,28 @@
+summary: Test the tag option
+
+prepare: |
+    if [ ! -f .spread-reuse.yaml ]; then
+        touch /run/spread-reuse.yaml
+        ln -s /run/spread-reuse.yaml .spread-reuse.yaml
+    fi
+
+restore: |
+    rm -f exec1.out exec2.out exec3.out
+
+execute: |
+    # Check the tests can be filtered by the tag passed as parameter
+    spread -tag tag-a lxd:ubuntu-16.04:checks/ &> exec1.out
+    grep 'Executing lxd:ubuntu-16.04:checks/test-a' exec1.out
+    grep 'Executing lxd:ubuntu-16.04:checks/test-b' exec1.out
+    grep 'Successful tasks: 2' exec1.out
+
+    # Check the case when there is not task matching the tag
+    spread -tag tag-c lxd:ubuntu-16.04:checks/ &> exec2.out || true
+    grep 'error: nothing matches provider filter' exec2.out
+
+    # Check the case when the tag option is not used
+    spread lxd:ubuntu-16.04:checks/ &> exec3.out
+    grep 'Executing lxd:ubuntu-16.04:checks/test-a' exec3.out
+    grep 'Executing lxd:ubuntu-16.04:checks/test-b' exec3.out
+    grep 'Executing lxd:ubuntu-16.04:checks/test-c' exec3.out
+    grep 'Successful tasks: 3' exec3.out


### PR DESCRIPTION
The tests could have a list of tags defined which then can be used to
filter the tests.

For example, if a test has a tad called offline, then when executing
"spread -tag offline <path>" just the tests with that specific tag will
be executed.