### PR TITLE
spread/client: workaround bash 4.3 subshell errexit issues

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -440,7 +440,7 @@ func join(scripts ...string) string {
 		}
 		buf.WriteString("(\n")
 		buf.WriteString(script)
-		buf.WriteString("\n)")
+		buf.WriteString("\n) || exit $?;\n")
 	}
 	return buf.String()
 }

--- a/tests/reboot-bash4.13/checks/t1/task.yaml
+++ b/tests/reboot-bash4.13/checks/t1/task.yaml
@@ -1,0 +1,8 @@
+summary: Ensure reboot works with bash4.13
+
+priority: 100
+
+execute: |
+    test "$SPREAD_REBOOT" == 0
+    
+    

--- a/tests/reboot-bash4.13/checks/t2/task.yaml
+++ b/tests/reboot-bash4.13/checks/t2/task.yaml
@@ -1,0 +1,4 @@
+summary: Ensure reboot works with bash4.13
+
+execute: |
+    test "$SPREAD_REBOOT" == 1

--- a/tests/reboot-bash4.13/spread.yaml
+++ b/tests/reboot-bash4.13/spread.yaml
@@ -1,0 +1,25 @@
+project: spread
+
+backends:
+    qemu:
+        systems:
+            - ubuntu-16.04:
+                username: ubuntu
+                password: ubuntu
+
+path: /home/test
+
+suites:
+    checks/: 
+        summary: Verification tasks.
+
+restore-each: |
+    echo "restore-each will reboot"
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT
+    fi
+
+restore: |
+    echo "does nothing but is needed to create subshells"
+
+# vim:ts=4:sw=4:et

--- a/tests/reboot-bash4.13/task.yaml
+++ b/tests/reboot-bash4.13/task.yaml
@@ -1,0 +1,30 @@
+summary: Test the qemu backend.
+
+prepare: |
+    if ! kvm-ok; then
+        echo "Nested KVM is not available on this system."
+        exit 1
+    fi
+
+    mkdir -p ~/.spread/qemu
+    if [ "$SPREAD_BACKEND" = qemu ]; then
+        ln -sf /dev/sda ~/.spread/qemu/ubuntu-16.04.img
+    else
+        apt install -y autopkgtest genisoimage
+        autopkgtest-buildvm-ubuntu-cloud -a amd64 -r xenial
+        mv autopkgtest-xenial-amd64.img ~/.spread/qemu/ubuntu-16.04.img
+    fi
+
+    if [ ! -f .spread-reuse.yaml ]; then
+        touch /run/spread-reuse.yaml
+        ln -s /run/spread-reuse.yaml .spread-reuse.yaml
+    fi
+
+execute: |
+    spread -vv -reuse -resend &> task.out
+
+    grep 'qemu:ubuntu-16.04:checks/main' task.out
+    grep '^WORKS$' task.out
+
+debug: |
+    cat task.out || true

--- a/tests/reboot/task.yaml
+++ b/tests/reboot/task.yaml
@@ -9,7 +9,7 @@ prepare: |
 execute: |
     spread -vv -reuse -resend &> task.out
 
-    cat task.out | awk -F= '/^REBOOT=/ {printf "%s,",$2}' | grep '0,1,2,foo,bar,'
+    cat task.out | awk -F= '/^REBOOT=/ {printf "%s,",$2}' | MATCH '0,1,2,foo,bar,'
     cat task.out | grep '^WORKS$'
 
 debug: |


### PR DESCRIPTION
Parts of the stage script (prepare, restore..) are assembled into one script
using subshells. REBOOT and ERROR helpers make the shell exit with special
status code 213 which also counts as an error exit status. Normally, we expect
the error exit status to bubble up and be observed by the SSH session runner.

However, due to bug in bash 4.3, this does not happen on systems using that
particular version. The set -e switch causes upper subshell to exit with status
1, instead of forwarding the exit status of the inner shell, provided the inner
one is not the last.

Thus an example script like this:

```
  set -eu
  set -x
  ( # stage

  (
    # snippet, eg. restore
    REBOOT
  )

  (
   # snippet, eg. restore-each
  )
  ) < /dev/null
```

Exits with status 1, instead of 213. This can be reproduced with minimal setup:

```
restore-each: |
    echo foo

restore: |
    echo doing reboot
    REBOOT
```

On a system with bash 4.3 (eg. Ubuntu 16.04), REBOOT is not executed during
restore.

ping @mvo5 @zyga @chipaca 