### PR TITLE
Allow to connect to the target system by using the ssh certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,9 @@ the number of reexecutions to do, being 0 the default value.
 ## Passwords and usernames
 
 To keep things simple and convenient, Spread prepares systems to connect over SSH
-as the root user using a single password for all systems. Unless explicitly defined
-via the `-pass` command line option, the password will be random and different on
-each run.
+as the root user using a single password for all systems. Unless explicitly defined either
+via the `-pass` command line option or via setting the cert field for the system.
+The password will be random and different on each run.
 
 Some of the supported backends may be unable to provide an image with the correct
 password in place, or with the correct SSH configuration for root to connect. In
@@ -585,12 +585,18 @@ backends:
             - ubuntu-16.04:
                 username: ubuntu
                 password: ubuntu
+            - ubuntu-core-16-64:
+                username: my-lp-user
+                cert: true
 ```
 
 If the password field is defined without a username, it specifies the password
 for root to connect over SSH.  If both username and password are provided,
 the credentials will be used to connect to the system, and password-less sudo
 must be available for the provided user.
+
+When the cert field is set to true, spread uses the ssh certificates for the current
+user to stablish the connection. In this scenario the password is not considered.
 
 In all cases the end result is the same: a system that executes scripts as root.
 

--- a/spread/humbox.go
+++ b/spread/humbox.go
@@ -166,6 +166,7 @@ func (p *humboxProvider) createMachine(ctx context.Context, system *System) (*hu
 
 	username := system.Username
 	password := system.Password
+	cert := system.Cert
 	if username == "" {
 		username = "root"
 	}
@@ -173,7 +174,7 @@ func (p *humboxProvider) createMachine(ctx context.Context, system *System) (*hu
 		password = p.options.Password
 	}
 
-	if err := waitServerUp(ctx, s, username, password); err != nil {
+	if err := waitServerUp(ctx, s, username, password, cert); err != nil {
 		if p.removeMachine(ctx, s) != nil {
 			return nil, &FatalError{fmt.Errorf("cannot allocate or deallocate (!) new Humbox server %s: %v", s, err)}
 		}

--- a/spread/project.go
+++ b/spread/project.go
@@ -117,6 +117,7 @@ type System struct {
 	Kernel   string
 	Username string
 	Password string
+	Cert     bool
 	Workers  int
 
 	// Only for Linode and Google so far.
@@ -1024,7 +1025,7 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 					return nil, err
 				}
 				system.Password = value
-			}
+		    }
 		}
 	}
 

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -923,6 +923,7 @@ Allocate:
 
 	username := system.Username
 	password := system.Password
+	cert := system.Cert
 	if username == "" {
 		username = "root"
 	}
@@ -934,7 +935,7 @@ Allocate:
 Dial:
 	for {
 		lerr := err
-		client, err = Dial(server, username, password)
+		client, err = Dial(server, username, password, cert)
 		if err == nil {
 			break
 		}
@@ -1005,10 +1006,11 @@ func (r *Runner) reuseServer(backend *Backend, system *System) *Client {
 		printf("Reusing %s...", server)
 		username := rsystem.Username
 		password := rsystem.Password
+		cert := system.Cert
 		if username == "" {
 			username = "root"
 		}
-		client, err := Dial(server, username, password)
+		client, err := Dial(server, username, password, cert)
 		if err != nil {
 			if r.options.Reuse {
 				printf("Cannot reuse %s at %s: %v", system, rsystem.Address, err)


### PR DESCRIPTION
This change is needed to connect to external core devices which still
not have any user created but the one registered through console-conf
setup.

This is an example of a configuration used to configure a system with
password and without.

    external:
        type: adhoc
        environment:
            SPREAD_EXTERNAL_ADDRESS: '$(HOST: echo
"${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}")'
        allocate: |
            ADDRESS $SPREAD_EXTERNAL_ADDRESS
        systems:
            - ubuntu-core-16-64:
                username: test
                password: ubuntu
            - ubuntu-core-16-64-cert:
                username: '$(HOST: echo "${SPREAD_USERNAME:-}")'
                cert: true