### PR TITLE
introduce NOMATCH assertion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A few helper functions are available for scripts to use:
 
  * _REBOOT_ - Reboot the system. See [below](#rebooting) for details.
  * _MATCH_ - Run `grep -q -e` on stdin. Without match, print error including content.
+ * _NOMATCH_ - Assert no match on stdin.  If match found, print error including content.
  * _ERROR_ - Fail script with provided error message only instead of script trace.
  * _FATAL_ - Similar to ERROR, but prevents retries. Specific to [adhoc backend](#adhoc).
  * _ADDRESS_ - Set allocated system address. Specific to [adhoc backend](#adhoc).

--- a/spread/client.go
+++ b/spread/client.go
@@ -366,6 +366,7 @@ func (c *Client) runPart(script string, dir string, env *Environment, mode outpu
 	// We also run it in a subshell, see
 	//  https://github.com/snapcore/spread/pull/67
 	buf.WriteString(rc(true, "MATCH() ( { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; grep -q -E \"$@\" <<< \"$stdin\" || { res=$?; echo \"grep error: pattern not found, got:\n$stdin\">&2; if [ $res != 1 ]; then echo \"unexpected grep exit status: $res\"; fi; return 1; }; )\n"))
+	buf.WriteString(rc(true, "NOMATCH() ( { set +xu; } 2> /dev/null; [ ${#@} -gt 0 ] || { echo \"error: missing regexp argument\"; return 1; }; local stdin=\"$(cat)\"; if echo \"$stdin\" | grep -q -E \"$@\"; then echo \"NOMATCH pattern='$@' found in:\n$stdin\">&2; return 1; fi; )\n"))
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
 	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")
@@ -795,6 +796,7 @@ func (s *localScript) run() (stdout, stderr []byte, err error) {
 	buf.WriteString("FATAL() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<FATAL>' || echo \"<FATAL $@>\"; exit 213; }\n")
 	buf.WriteString("ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n")
 	buf.WriteString("MATCH() { { set +xu; } 2> /dev/null; local stdin=$(cat); echo $stdin | grep -q -E \"$@\" || { echo \"error: pattern not found on stdin:\\n$stdin\">&2; return 1; }; }\n")
+	buf.WriteString("NOMATCH() { { set +xu; } 2> /dev/null; local stdin=$(cat); if echo $stdin | grep -q -E \"$@\"; then echo \"NOMATCH pattern='$@' found in:\n$stdin\">&2; return 1; fi }\n")
 	buf.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
 	buf.WriteString("export DEBIAN_PRIORITY=critical\n")
 	buf.WriteString("export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\n")

--- a/tests/nomatch/checks/main/task.yaml
+++ b/tests/nomatch/checks/main/task.yaml
@@ -1,0 +1,34 @@
+summary: Test the NOMATCH function.
+
+execute: |
+    if echo -e "error: oops, something went wrong" | NOMATCH error > task.out 2> task.err; then
+        echo "NOMATCH should have failed single-line test."
+        exit 1
+    fi
+
+    if echo -e "foo\nerror\nbar\n" | NOMATCH error > task.out 2> task.err; then
+        echo "NOMATCH should have failed multi-line test."
+        exit 1
+    fi
+
+    cat task.out
+    test "$(wc -l < task.out)" -eq 0
+
+    cat task.err
+    cat task.err | grep "^NOMATCH pattern='error' found in:$"
+    cat task.err | grep "^foo$"
+    cat task.err | grep "^error$"
+    cat task.err | grep "^bar$"
+
+    echo -e "foo\nbar\n" | NOMATCH error &> task.out
+
+    cat task.out
+    test "$(wc -l < task.out)" -eq 0
+
+    echo "Ensure it's using the extended regexp syntax."
+    echo -e "foo" | NOMATCH "(error|warning)"
+
+    echo "Ensure input can be multiline."
+    echo -e "foo\nxxERRORxx\nbaz\n" | NOMATCH '^ERROR$'
+
+    echo WORKS

--- a/tests/nomatch/spread.yaml
+++ b/tests/nomatch/spread.yaml
@@ -1,0 +1,14 @@
+project: spread
+
+backends:
+    lxd:
+        systems:
+            - ubuntu-16.04
+
+path: /home/test
+
+suites:
+    checks/:
+        summary: Verification tasks.
+
+# vim:ts=4:sw=4:et

--- a/tests/nomatch/task.yaml
+++ b/tests/nomatch/task.yaml
@@ -1,0 +1,15 @@
+summary: Test the NOMATCH function.
+
+prepare: |
+    if [ ! -f .spread-reuse.yaml ]; then
+        touch /run/spread-reuse.yaml
+        ln -s /run/spread-reuse.yaml .spread-reuse.yaml
+    fi
+
+execute: |
+    spread -vv -reuse -resend &> task.out
+
+    cat task.out | grep '^WORKS$'
+
+debug: |
+    cat task.out || true


### PR DESCRIPTION
Using MATCH -v works fine for single-line input, but fails
to make an equivalent assertion on multi-line input.  Add
a new helper which will error if match is found.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>