### PR TITLE
runner: pass --exclude-vcs-ignores to tar

### DIFF
--- a/spread/runner.go
+++ b/spread/runner.go
@@ -277,7 +277,11 @@ func (r *Runner) prepareContent() (err error) {
 		return fmt.Errorf("cannot remove temporary content file: %v", err)
 	}
 
-	args := []string{"c", "--exclude=.spread-reuse.*"}
+	args := []string{
+		"-c",
+		"--exclude=.spread-reuse.*",
+		"--exclude-vcs-ignores",
+	}
 	if r.project.Repack == "" {
 		args[0] = "cz"
 	}


### PR DESCRIPTION
This allows to use .gitignore and other similar files if they are
present in the current working directory. Note that this is not a
breaking change in any way. The following paragraphs explain why.

When tar is invoked with --exclude-vcs-ignores and the "." as the list
of things to pack, then the exclude logic works correctly. When tar is
invoked with the same option but with each directory and file spelled
out explicitly then --exclude-vcs-ignores does nothing.

This can be tested as follows. Create a .gitignore with *.o rule. Create
a directory subdir with foo.o inside and run:

    tar -c --exclude-vcs-ignores subdir | tar -t | grep -E '\.o$'
    tar -c --exclude-vcs-ignores .gitignore subdir | tar -t | grep -E '\.o$'
    tar -c --exclude-vcs-ignores . | tar -t | grep -E '\.o$'

The first and second commands both ignore the rules in the .gitignore
file. The last command works as people might expect.

Spread has a notion of include list, which contains the set of project
files to send for testing. Spread computes the include list if one is
not defined in spread.yaml. The computed value contains all the files
and directories in the root of the project with the files matching
".spread-reuse.*" filtered-out. Curiously the very tar command this
patch is changing also explicitly excludes the same pattern, which seems
redundant.

The consequence is that for the new options to actually do something in
an existing spread project one needs to explicitly modify the
spread.yaml to read:

    include: [.]

This modification to a project can be coupled with the removal of the
typical exclude list, since it can be typically moved entirely to
.gitignore or similar.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
