### PR TITLE
runner: remove filterDir, default include to "."

### DIFF
--- a/spread/runner.go
+++ b/spread/runner.go
@@ -289,10 +289,7 @@ func (r *Runner) prepareContent() (err error) {
 	}
 	include := r.project.Include
 	if len(include) == 0 {
-		include, err = filterDir(r.project.Path)
-		if err != nil {
-			return fmt.Errorf("cannot list project directory: %v", err)
-		}
+		include = []string{"."}
 	}
 	args = append(args, include...)
 
@@ -1097,23 +1094,4 @@ func logNames(f func(format string, args ...interface{}), prefix string, jobs []
 	sort.Strings(names)
 	const dash = "\n    - "
 	f("%s: %d%s%s", prefix, len(names), dash, strings.Join(names, dash))
-}
-
-func filterDir(path string) (names []string, err error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	names, err = f.Readdirnames(0)
-	if err != nil {
-		return nil, err
-	}
-	var filtered []string
-	for _, name := range names {
-		if !strings.HasPrefix(name, ".spread-reuse.") {
-			filtered = append(filtered, name)
-		}
-	}
-	return filtered, nil
 }

--- a/tests/explicit-include/checks/main/task.yaml
+++ b/tests/explicit-include/checks/main/task.yaml
@@ -1,0 +1,7 @@
+summary: Ensure that .spread-reuse files are not sent 
+execute: |
+    # This file is implicitly excluded
+    test ! -e "$SPREAD_PATH/.spread-reuse.test"
+    # Those files are no longer included
+    test ! -f "$SPREAD_PATH/file"
+    test ! -f "$SPREAD_PATH/dir/file"

--- a/tests/explicit-include/spread.yaml
+++ b/tests/explicit-include/spread.yaml
@@ -1,0 +1,10 @@
+project: spread
+backends:
+    lxd:
+        systems:
+            - ubuntu-16.04
+path: /home/test
+include: [checks/]
+suites:
+    checks/:
+        summary: Verification tasks.

--- a/tests/explicit-include/task.yaml
+++ b/tests/explicit-include/task.yaml
@@ -1,0 +1,12 @@
+summary: Check that .spread-reuse is not sent 
+prepare: |
+    touch .spread-reuse.test
+    touch file
+    mkdir dir
+    touch dir/file
+execute: |
+    spread -v
+restore: |
+    rm -f .spread-reuse.test
+    rm -f file dir/file
+    rmdir dir

--- a/tests/implicit-include/checks/main/task.yaml
+++ b/tests/implicit-include/checks/main/task.yaml
@@ -1,0 +1,7 @@
+summary: Ensure that .spread-reuse files are not sent 
+execute: |
+    # This file is implicitly excluded
+    test ! -e "$SPREAD_PATH/.spread-reuse.test"
+    # Those files are implicitly included
+    test -f "$SPREAD_PATH/file"
+    test -f "$SPREAD_PATH/dir/file"

--- a/tests/implicit-include/spread.yaml
+++ b/tests/implicit-include/spread.yaml
@@ -1,0 +1,10 @@
+project: spread
+backends:
+    lxd:
+        systems:
+            - ubuntu-16.04
+path: /home/test
+# include: [.] is defined implicitly here
+suites:
+    checks/:
+        summary: Verification tasks.

--- a/tests/implicit-include/task.yaml
+++ b/tests/implicit-include/task.yaml
@@ -1,0 +1,12 @@
+summary: Check that .spread-reuse is not sent 
+prepare: |
+    touch .spread-reuse.test
+    touch file
+    mkdir dir
+    touch dir/file
+execute: |
+    spread -v
+restore: |
+    rm -f .spread-reuse.test
+    rm -f file dir/file
+    rmdir dir


### PR DESCRIPTION
The include list was defaulting to all the files and directories in the
project, except for files matching .spread-reuse-*. The list of files is
then forwarded to tar, along with the same exclude rule.

This significantly simplifies the invocation of tar and opens up the
possibility of using .gitignore, which requires tar to read the root of
the directory to work.

Two new spread tests check this behavior.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>