### PR TITLE
tests: Fix adhoc test

### DIFF
--- a/tests/adhoc/task.yaml
+++ b/tests/adhoc/task.yaml
@@ -11,8 +11,8 @@ execute: |
     spread -reuse lxd:
 
     export ADHOC_USERNAME=root
-    export ADHOC_PASSWORD=$(cat .spread-reuse.yaml | awk '/password:/ { print $2 }')
-    export ADHOC_ADDRESS=$(cat .spread-reuse.yaml | awk '/address:/ { print $2 }')
+    export ADHOC_PASSWORD=$(cat .spread-reuse.yaml | awk '/password:/ { print $2 }' | head -n1)
+    export ADHOC_ADDRESS=$(cat .spread-reuse.yaml | awk '/address:/ { print $2 }' | head -n1)
 
     spread -vv -resend adhoc: &> task.out
 
@@ -22,4 +22,5 @@ execute: |
     grep '^WORKS$' task.out
 
 debug: |
+    cat .spread-reuse.yaml || true
     cat task.out || true


### PR DESCRIPTION
Always take first backend which is lxd because depending on the previous
tests could be more than one backend use in teh .spread-reuse.yaml file

The test fails when the qemu test is executed before

google:ubuntu-18.04-64 .../tests/adhoc# cat .spread-reuse.yaml
backends:
  lxd:
    systems:
    - ubuntu-16.04:
        password: 9facef8d38c59bba
        address: 10.4.66.64
        data:
          name: spread-1-ubuntu-16-04
  qemu:
    systems:
    - ubuntu-16.04:
        username: ubuntu
        password: ubuntu
        address: localhost:59327
        data:
          pid: 7046