### PR TITLE
tests: fix ad-hoc test

### DIFF
--- a/tests/adhoc/task.yaml
+++ b/tests/adhoc/task.yaml
@@ -11,8 +11,8 @@ execute: |
     spread -reuse lxd:
 
     export ADHOC_USERNAME=root
-    export ADHOC_PASSWORD=$(cat .spread-reuse.yaml | awk '/password:/ { print $2 }')
-    export ADHOC_ADDRESS=$(cat .spread-reuse.yaml | awk '/address:/ { print $2 }')
+    export ADHOC_PASSWORD=$(cat .spread-reuse.yaml | awk '/password:/ { print $2 }' | head -n1)
+    export ADHOC_ADDRESS=$(cat .spread-reuse.yaml | awk '/address:/ { print $2 }' | head -n1)
 
     spread -vv -resend adhoc: &> task.out
 
@@ -22,4 +22,5 @@ execute: |
     grep '^WORKS$' task.out
 
 debug: |
+    cat .spread-reuse.yaml || true
     cat task.out || true

--- a/tests/adhoc/task.yaml
+++ b/tests/adhoc/task.yaml
@@ -11,8 +11,8 @@ execute: |
     spread -reuse lxd:
 
     export ADHOC_USERNAME=root
-    export ADHOC_PASSWORD=$(cat .spread-reuse.yaml | awk '/password:/ { print $2 }' | head -n1)
-    export ADHOC_ADDRESS=$(cat .spread-reuse.yaml | awk '/address:/ { print $2 }' | head -n1)
+    export ADHOC_PASSWORD="$(python3 -c 'import sys, yaml; print(yaml.load(sys.stdin)["backends"]["lxd"]["systems"][0]["ubuntu-16.04"]["password"])' < .spread-reuse.yaml)"
+    export ADHOC_ADDRESS="$(python3 -c 'import sys, yaml; print(yaml.load(sys.stdin)["backends"]["lxd"]["systems"][0]["ubuntu-16.04"]["address"])' < .spread-reuse.yaml)"
 
     spread -vv -resend adhoc: &> task.out
 


### PR DESCRIPTION
This branch fixes the ad-hoc test which can fail on hand-crafted parsing of .spread-reuse.yaml.
The parsing was made to be more robust with Python.

This is a follow-up for #91 but I was unable to push it there.
