### PR TITLE
qemu: invoke qemu in a portable way

### DIFF
--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -114,7 +114,7 @@ func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, er
 	serial := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+100)
 	monitor := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+200)
 	fwd := fmt.Sprintf("user,hostfwd=tcp:127.0.0.1:%d-:22", port)
-	cmd := exec.Command("kvm", "-snapshot", "-m", strconv.Itoa(mem), "-net", "nic", "-net", fwd, "-serial", serial, "-monitor", monitor, path)
+	cmd := exec.Command("qemu-system-x86_64", "-enable-kvm", "-snapshot", "-m", strconv.Itoa(mem), "-net", "nic", "-net", fwd, "-serial", serial, "-monitor", monitor, path)
 	if os.Getenv("SPREAD_QEMU_GUI") != "1" {
 		cmd.Args = append([]string{cmd.Args[0], "-nographic"}, cmd.Args[1:]...)
 	}


### PR DESCRIPTION
The kvm binary is non-standard packaging tweak in available in the
Debian world. To work on Fedora and all the other systems as well, we
can just invoke qemu-system-x86_64 with the -enable-kvm switch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>