### PR TITLE
spread: add support to define a custom bios with the qemu backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,10 @@ see the `-pass` command line option).
 The QEMU backend is run with the `-nographic` option by default. This
 may be changed with `export SPREAD_QEMU_GUI=1`.
 
+The bios that qemu uses can be changed via the SPREAD_QEMU_BIOS
+environment variable. To switch to an UEFI bios on Ubuntu
+`export SPREAD_QEMU_BIOS=/usr/share/OVMF/OVMF_CODE.ms.fd` can be used.
+
 Note that at the moment QEMU is run via the `kvm` script, which enables
 the KVM performance optimizations for the local architecture. This will
 not work for other architectures, though. This problem may be easily

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -118,6 +118,10 @@ func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, er
 	if os.Getenv("SPREAD_QEMU_GUI") != "1" {
 		cmd.Args = append([]string{cmd.Args[0], "-nographic"}, cmd.Args[1:]...)
 	}
+	if biosPath := os.Getenv("SPREAD_QEMU_BIOS"); biosPath != "" {
+		cmd.Args = append([]string{cmd.Args[0], "-bios", biosPath}, cmd.Args[1:]...)
+	}
+
 	printf("Serial and monitor for %s available at ports %d and %d.", system, port+100, port+200)
 
 	err := cmd.Start()


### PR DESCRIPTION
For some tests it is important to customize the bios that qemu
uses. One example is the Ubuntu Core 20 project. For the spread
testing there we need a qemu that uses the OVMF uefi bios.

The location of this bios is different on all distributions so
defining it in the spread.yaml seems not appropriate.