### PR TITLE
spread: add support for system specific "flags" and use in qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,7 @@ backends:
             - ubuntu-16.04:
                 username: ubuntu
                 password: ubuntu
+                flags: [virtio]
 ```
 
 For this example to work, a QEMU image must be made available under
@@ -825,7 +826,9 @@ running session as usual for every other backend (random by default,
 see the `-pass` command line option).
 
 The QEMU backend is run with the `-nographic` option by default. This
-may be changed with `export SPREAD_QEMU_GUI=1`.
+may be changed with `export SPREAD_QEMU_GUI=1` and is useful for
+interactive debugging. The backend also supports the "virtio" flag
+for each system that enables virtio on the used image.
 
 Note that at the moment QEMU is run via the `kvm` script, which enables
 the KVM performance optimizations for the local architecture. This will

--- a/spread/project.go
+++ b/spread/project.go
@@ -119,6 +119,10 @@ type System struct {
 	Password string
 	Workers  int
 
+	// Flags for the system like "virtio", "uefi" or similar to enable
+	// backend specific features.
+	Flags []string
+
 	// Only for Linode and Google so far.
 	Storage Size
 

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -114,7 +114,11 @@ func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, er
 	serial := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+100)
 	monitor := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+200)
 	fwd := fmt.Sprintf("user,hostfwd=tcp:127.0.0.1:%d-:22", port)
-	cmd := exec.Command("kvm", "-snapshot", "-m", strconv.Itoa(mem), "-net", "nic", "-net", fwd, "-serial", serial, "-monitor", monitor, path)
+	drive := fmt.Sprintf("file=%s", path)
+	if contains(system.Flags, "virtio") {
+		drive += ",if=virtio"
+	}
+	cmd := exec.Command("kvm", "-snapshot", "-m", strconv.Itoa(mem), "-net", "nic", "-net", fwd, "-serial", serial, "-monitor", monitor, "-drive", drive)
 	if os.Getenv("SPREAD_QEMU_GUI") != "1" {
 		cmd.Args = append([]string{cmd.Args[0], "-nographic"}, cmd.Args[1:]...)
 	}


### PR DESCRIPTION
This commit adds a concept of system specific flags. This is useful
to enable certain properties on the given system. The first use-case
is to switch virtio on for a specific system. This will be useful
for UC20 where the UEFI grub bootloader is very very slow (minutes)
when loading the kernel in non-virtio mode.

The flags concept will probably be useful for other use-cases as
well. One example is to add "uefi" to google backend so that
systems that have this flag are created with UEFI enabled.

An alternative approach would be to just check an environment variable
like SPREAD_QEMU_VIRTIO=1. Enabling this globally is risky because
the device name change from /dev/sda to /dev/vda so tests that look at
those will need updating.