### PR TITLE
spread: deal with crashing qemu in waitPortUp()

### DIFF
--- a/spread/adhoc.go
+++ b/spread/adhoc.go
@@ -92,7 +92,7 @@ func (p *adhocProvider) Allocate(ctx context.Context, system *System) (Server, e
 	}
 
 	printf("Waiting for %s to make SSH available at %s...", system, addr)
-	if err := waitPortUp(ctx, system, s.address); err != nil {
+	if err := waitPortUp(ctx, system, s.address, nil); err != nil {
 		s.Discard(ctx)
 		return nil, fmt.Errorf("cannot connect to %s at %s: %s", s, s.Address(), err)
 	}

--- a/spread/client_test.go
+++ b/spread/client_test.go
@@ -1,0 +1,88 @@
+package spread_test
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/spread/spread"
+)
+
+type mockSystem string
+
+func (ms mockSystem) String() string { return string(ms) }
+
+type clientSuite struct {
+	ctx    context.Context
+	system mockSystem
+}
+
+var _ = Suite(&clientSuite{})
+
+func (s *clientSuite) SetUpTest(c *C) {
+	s.ctx = context.Background()
+	s.system = mockSystem("some-system")
+}
+
+func (s *clientSuite) TestWaitPortUpHappyNoCmd(c *C) {
+	connectedCh := make(chan interface{})
+	ln, err := net.Listen("tcp", "localhost:0")
+	c.Assert(err, IsNil)
+	go func() {
+		conn, err := ln.Accept()
+		c.Assert(err, IsNil)
+		conn.Close()
+		close(connectedCh)
+	}()
+
+	err = spread.WaitPortUp(s.ctx, s.system, ln.Addr().String(), nil)
+	c.Assert(err, IsNil)
+
+	// ensure waitPortUp really connected to our listener
+	timeout := time.NewTicker(5 * time.Second)
+	select {
+	case <-connectedCh:
+		break
+	case <-timeout.C:
+		c.Fatalf("timeout waiting for connection")
+	}
+}
+
+func (s *clientSuite) TestWaitPortUpHappyCmdHappy(c *C) {
+	cmd := exec.Command("sleep", "9999")
+	cmd.Start()
+	defer cmd.Process.Kill()
+
+	connectedCh := make(chan interface{})
+	ln, err := net.Listen("tcp", "localhost:0")
+	c.Assert(err, IsNil)
+	go func() {
+		conn, err := ln.Accept()
+		c.Assert(err, IsNil)
+		conn.Close()
+		close(connectedCh)
+	}()
+
+	err = spread.WaitPortUp(s.ctx, s.system, ln.Addr().String(), cmd)
+	c.Assert(err, IsNil)
+
+	// ensure waitPortUp really connected to our listener
+	timeout := time.NewTicker(5 * time.Second)
+	select {
+	case <-connectedCh:
+		break
+	case <-timeout.C:
+		c.Fatalf("timeout waiting for connection")
+	}
+}
+
+func (s *clientSuite) TestWaitPortUpHappyCmdFailing(c *C) {
+	cmd := exec.Command("false", "hope")
+	cmd.Start()
+
+	err := spread.WaitPortUp(s.ctx, s.system, "localhost:0", cmd)
+	c.Assert(err, ErrorMatches, `process exited unexpectedly while waiting for address localhost:0 \(wstatus=256\)`)
+}

--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -1,0 +1,3 @@
+package spread
+
+var WaitPortUp = waitPortUp

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -115,6 +115,8 @@ func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, er
 	monitor := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+200)
 	fwd := fmt.Sprintf("user,hostfwd=tcp:127.0.0.1:%d-:22", port)
 	cmd := exec.Command("kvm", "-snapshot", "-m", strconv.Itoa(mem), "-net", "nic", "-net", fwd, "-serial", serial, "-monitor", monitor, path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if os.Getenv("SPREAD_QEMU_GUI") != "1" {
 		cmd.Args = append([]string{cmd.Args[0], "-nographic"}, cmd.Args[1:]...)
 	}
@@ -135,7 +137,7 @@ func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, er
 	}
 
 	printf("Waiting for %s to make SSH available...", system)
-	if err := waitPortUp(ctx, system, s.address); err != nil {
+	if err := waitPortUp(ctx, system, s.address, cmd); err != nil {
 		s.Discard(ctx)
 		return nil, err
 	}


### PR DESCRIPTION
Someones qemu crashes or dies while starting up. If that happens
spread does not detected it and keeps trying to connect to the
port until it times out. This leaves the user in the dark why
the connection did not happen.

This commit improves this in two ways:
1. Show the stdout/stderr output of qemu on the terminal to
   ensure that users are aware of any issues there.
2. Add a check in waitPortUp() to detect if the command that
   is responsible for the setting up of the port exited in an
   unexpected way.