### PR TITLE
Adding maxResults parameters when requesting images from google backend

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -256,14 +256,11 @@ Outer:
 func (p *googleProvider) getLastCreatedImage(images []googleImage) (image googleImage) {
 	var lastImageCreated googleImage
 	lastImageCreated = images[0]
-	printf("Initial time %v", lastImageCreated)
 	for i := range images[1:] {
-		printf("Parsing time %v", images[i])
 		if lastImageCreated.CreationTimestamp.Before(images[i].CreationTimestamp) {
 			lastImageCreated = images[i]
 		}
 	}
-	printf("Final time %v", lastImageCreated)
 	return lastImageCreated
 }
 

--- a/spread/google.go
+++ b/spread/google.go
@@ -253,7 +253,7 @@ Outer:
 	return true
 }
 
-func (p *googleProvider) getLastCreatedImage(images []googleImage) (image googleImage) {
+func (p *googleProvider) newestCreatedImage(images []googleImage) (image googleImage) {
 	var lastImageCreated googleImage
 	lastImageCreated = images[0]
 	for i := range images[1:] {
@@ -323,7 +323,7 @@ func (p *googleProvider) image(system *System) (image *googleImage, family bool,
 			}
 		}
 		if len(matchingImages) > 0 {
-			image := p.getLastCreatedImage(matchingImages)
+			image := p.newestCreatedImage(matchingImages)
 			return &image, true, nil
 		}
 
@@ -336,7 +336,7 @@ func (p *googleProvider) image(system *System) (image *googleImage, family bool,
 			}
 		}
 		if len(matchingImages) > 0 {
-			image := p.getLastCreatedImage(matchingImages)
+			image := p.newestCreatedImage(matchingImages)
 			return &image, image.Family != "", nil
 		}
 	}
@@ -401,8 +401,6 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 			CreationTimestamp: 	parsedCreationTimestamp,
 		})
 	}
-
-
 
 	return cache.images, err
 }


### PR DESCRIPTION
The ideas of this change is to get up to 500 images from google backend.
This is a workaound for the paginatino issue.

The problem with the order parameter is that because an issue in the
gcloud api, when the orderBy parameter is used, the maxResults does not
work.

As the results are not so many, the idea is to manually order the
results.

I already submitted an issue explaining that bad behaviour:
https://issuetracker.google.com/issues/149183460