### PR TITLE
Adding option for systems created on google to start with secure boot enabled

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -433,6 +433,15 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 		diskParams["diskSizeGb"] = int(system.Storage / gb)
 	}
 
+	secureBootParams := googleParams{}
+	if system.SecureBoot {
+		secureBootParams = googleParams{
+			"enableSecureBoot": true,
+			"enableVtpm": true,
+			"enableIntegrityMonitoring": true,
+		}
+	}
+
 	params := googleParams{
 		"name":        name,
 		"machineType": "zones/" + p.gzone() + "/machineTypes/" + plan,
@@ -456,6 +465,7 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 		"tags": googleParams{
 			"items": []string{"spread"},
 		},
+		"shieldedInstanceConfig": secureBootParams,
 	}
 
 	var op googleOperation

--- a/spread/project.go
+++ b/spread/project.go
@@ -122,6 +122,9 @@ type System struct {
 	// Only for Linode and Google so far.
 	Storage Size
 
+	// Only for Google so far.
+	SecureBoot	bool
+
 	Environment *Environment
 	Variants    []string
 


### PR DESCRIPTION
This is a feature to enable the secure boot option in google instances.

It is needed for running some uc20 tests because the key sealing in the
encryption tests needs secure boot to be enabled

The configuration in the spread.yaml should be:
systems:
    - ubuntu-20.04-64:
         workers: 6
         secureboot: true