### PR TITLE
google: only configure shielded instance when secure boot is enabled

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -433,15 +433,6 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 		diskParams["diskSizeGb"] = int(system.Storage / gb)
 	}
 
-	secureBootParams := googleParams{}
-	if system.SecureBoot {
-		secureBootParams = googleParams{
-			"enableSecureBoot": true,
-			"enableVtpm": true,
-			"enableIntegrityMonitoring": true,
-		}
-	}
-
 	params := googleParams{
 		"name":        name,
 		"machineType": "zones/" + p.gzone() + "/machineTypes/" + plan,
@@ -465,7 +456,14 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 		"tags": googleParams{
 			"items": []string{"spread"},
 		},
-		"shieldedInstanceConfig": secureBootParams,
+	}
+
+	if system.SecureBoot {
+		params["shieldedInstanceConfig"] = googleParams{
+			"enableSecureBoot":          true,
+			"enableVtpm":                true,
+			"enableIntegrityMonitoring": true,
+		}
 	}
 
 	var op googleOperation

--- a/spread/project.go
+++ b/spread/project.go
@@ -123,7 +123,7 @@ type System struct {
 	Storage Size
 
 	// Only for Google so far.
-	SecureBoot	bool
+	SecureBoot bool `yaml:"secure-boot"`
 
 	Environment *Environment
 	Variants    []string


### PR DESCRIPTION
Set shielded instance configurations only when secure boot is enabled,
using an empty configuration is not well-received in some systems. Also
change the option to enable secure boot to "secure-boot" to be consistent
with other options that use dash between words.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>