### PR TITLE
Bump base version of go to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.10"
+  - "1.13"
 
 env:
   global:

--- a/spread.yaml
+++ b/spread.yaml
@@ -8,7 +8,7 @@
 project: spread
 
 environment:
-    GOVERSION: 1.10.4
+    GOVERSION: 1.13.8
     GOHOME: /home/test
     GOPATH: $GOHOME
     PATH: $GOHOME/bin:$PATH


### PR DESCRIPTION
There are two main reasons:

Go 1.10 fails to `go get` dependencies of spread as they have introduced build
flags unrecognized by 1.10, which causes spurious duplicate symbol errors. An
example can be seen on the test logs from
https://github.com/snapcore/spread/pull/111

    The command "eval go get -v -t ./... " failed.
    # golang.org/x/term
    ../../../golang.org/x/term/term_unix_linux.go:9:26: ioctlReadTermios redeclared in this block
	previous declaration at ../../../golang.org/x/term/term_unix_aix.go:9:26
    ../../../golang.org/x/term/term_unix_linux.go:10:27: ioctlWriteTermios redeclared in this block
	previous declaration at ../../../golang.org/x/term/term_unix_aix.go:10:2

This makes CI broken, this was not noticed simply because of low rate of
activity on the project.

The second reason is to get improved `go vet`, as certain issues have gone
unnoticed simply because the tooling was older.

I chose to bump the base version to Go 1.13 as it is used in Ubuntu 20.04 and
represents a reasonable upgrade.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>