### PR TITLE
Fix OptionalInt.String use of strconv.FormatInt

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -1327,7 +1327,7 @@ type OptionalInt struct {
 }
 
 func (s OptionalInt) String() string {
-	return strconv.FormatInt(s.Value, 64)
+	return strconv.FormatInt(s.Value, 10)
 }
 
 func (s *OptionalInt) UnmarshalYAML(u func(interface{}) error) error {

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/snapcore/spread/spread"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -52,4 +53,26 @@ func (s *FilterSuite) TestFilter(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(f.Pass(job), Equals, false, Commentf("Filter: %q", s))
 	}
+}
+
+type projectSuite struct{}
+
+var _ = Suite(&projectSuite{})
+
+func (s *projectSuite) TestOptionalInt(c *C) {
+	optInts := struct {
+		Priority spread.OptionalInt `yaml:"priority"`
+		NotSet   spread.OptionalInt `yaml:"not-set"`
+	}{}
+	inp := []byte("priority: 100")
+
+	err := yaml.Unmarshal(inp, &optInts)
+	c.Assert(err, IsNil)
+	c.Check(optInts.Priority.IsSet, Equals, true)
+	c.Check(optInts.Priority.Value, Equals, int64(100))
+	c.Check(optInts.Priority.String(), Equals, "100")
+
+	c.Check(optInts.NotSet.IsSet, Equals, false)
+	c.Check(optInts.NotSet.Value, Equals, int64(0))
+	c.Check(optInts.NotSet.String(), Equals, "0")
 }


### PR DESCRIPTION
The second argument to strconv.FormatInt is not integer size, but
numeric base. This is reported by go vet, as base cannot be larger than
36.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>