### PR TITLE
Fix actions workflow and discard workers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,32 +18,21 @@ jobs:
           sudo apt-get update
           sudo apt install -y xdelta3
 
-      - name: Setup go version
-        uses: actions/setup-go@v2
-        with:
-          # Using the lastest available go version for focal
-          go-version: 1.13.8
+      - uses: actions/checkout@v2
 
-      - name: Set environment
-        run: |
-          echo "GOHOME=${{ github.workspace }}" >> "$GITHUB_ENV"
-          echo "GOPATH=${{ github.workspace }}" >> "$GITHUB_ENV"
+      - name: Install spread
+        run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
 
-      - name: Checkout project
-        uses: actions/checkout@v2
-        with:
-          path: src/github.com/snapcore/spread
-
-      - name: Build spread
-        run: |
-          cd ${{ github.workspace }}/src/github.com/snapcore/spread
-          go get ./cmd/spread
-          
-      - name: run tests
+      - name: Run tests
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
         run: |
-          cd ${{ github.workspace }}/src/github.com/snapcore/spread
-          mkdir -p bin
-          cp -f "$GOHOME/bin/spread" ./bin/spread
-          "$GOHOME/bin/spread" google:
+          spread google:
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,21 +11,11 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt install -y xdelta3
-
       - uses: actions/checkout@v2
 
-      - name: Install spread
-        run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
-
       - name: Run tests
-        env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
         run: |
           spread google:
 


### PR DESCRIPTION
The idea is to use the published spread to trigger the tests execution.

We don't need to build spread in the github action machine because then
spread is built and tested in the target system.

Also it is included a step to discard workers in case it is needed.