### PR TITLE
Display the serial output in case the connection to the instance is lost

### DIFF
--- a/spread/adhoc.go
+++ b/spread/adhoc.go
@@ -58,6 +58,10 @@ func (s *adhocServer) Discard(ctx context.Context) error {
 	return nil
 }
 
+func (s *adhocServer) SerialOutput() ([]byte, error) {
+	return nil, nil
+}
+
 func (p *adhocProvider) Backend() *Backend {
 	return p.backend
 }

--- a/spread/google.go
+++ b/spread/google.go
@@ -150,6 +150,20 @@ func (s *googleServer) Discard(ctx context.Context) error {
 	return s.p.removeMachine(ctx, s)
 }
 
+func (s *googleServer) SerialOutput() ([]byte, error) {
+	var err error
+	var result struct {
+		Contents string
+	}
+
+	err = s.p.doz("GET", fmt.Sprintf("/instances/%s/serialPort?port=1", s.d.Name), nil, &result)
+	if err != nil {
+		printf("Cannot get console output for %s: %v", s, err)
+		return nil, fmt.Errorf("cannot get console output for %s: %v", s, err)
+	}
+	return []byte(result.Contents), nil
+}
+
 const googleStartupScript = `
 echo root:%s | chpasswd
 

--- a/spread/humbox.go
+++ b/spread/humbox.go
@@ -117,6 +117,10 @@ func (s *humboxServer) Discard(ctx context.Context) error {
 	return s.p.removeMachine(ctx, s)
 }
 
+func (s *humboxServer) SerialOutput() ([]byte, error) {
+	return nil, nil
+}
+
 func (p *humboxProvider) GarbageCollect() error {
 	return nil
 }

--- a/spread/linode.go
+++ b/spread/linode.go
@@ -363,6 +363,10 @@ func (s *linodeServer) Discard(ctx context.Context) error {
 	return err
 }
 
+func (s *linodeServer) SerialOutput() ([]byte, error) {
+	return nil, nil
+}
+
 type linodeListResult struct {
 	Data []linodeServerData `json:"DATA"`
 }

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -72,6 +72,10 @@ func (s *lxdServer) Discard(ctx context.Context) error {
 	return nil
 }
 
+func (s *lxdServer) SerialOutput() ([]byte, error) {
+	return nil, nil
+}
+
 func (p *lxdProvider) Backend() *Backend {
 	return p.backend
 }

--- a/spread/provider.go
+++ b/spread/provider.go
@@ -22,6 +22,7 @@ type Server interface {
 	Provider() Provider
 	Address() string
 	Discard(ctx context.Context) error
+	SerialOutput() ([]byte, error)
 	ReuseData() interface{}
 	System() *System
 	Label() string

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -72,6 +72,10 @@ func (s *qemuServer) Discard(ctx context.Context) error {
 	return nil
 }
 
+func (s *qemuServer) SerialOutput() ([]byte, error) {
+	return nil, nil
+}
+
 func (p *qemuProvider) Backend() *Backend {
 	return p.backend
 }

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -485,6 +485,12 @@ func (r *Runner) run(client *Client, job *Job, verb string, context interface{},
 			output, err := client.Trace(debug, dir, job.Environment)
 			if err != nil {
 				printft(start, startTime|endTime|startFold|endFold, "Error debugging %s (%s) : %v", contextStr, server.Label(), err)
+				output, err := server.SerialOutput()
+				if err != nil {
+					printft(start, startTime|endTime|startFold|endFold, "Error retrieving serial output: %v", err)
+				} else if len(output) > 0 {
+					printft(start, startTime|endTime|startFold|endFold, "Serial output for %s (%s) : %v", contextStr, server.Label(), outputErr(output, nil))	
+				}				
 			} else if len(output) > 0 {
 				printft(start, startTime|endTime|startFold|endFold, "Debug output for %s (%s) : %v", contextStr, server.Label(), outputErr(output, nil))
 			}


### PR DESCRIPTION
The idea is to show the serial output in case the client loses the connection to the instance.

The implementation is just completed for the google backend because for
the other backends it is easy to manually get the serial output in case
the connection is lost. 

As the following change could be included a new option like '-serial-lines 20' to show the last 20 lines of the serial output, or perhaps to predefine by default a number of lines 

An example of the output is on here: https://paste.ubuntu.com/p/k6cYvMgxPj/