### PR TITLE
Use greedy regex for $(HOST: )

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -1090,8 +1090,8 @@ func (s stringer) String() string { return string(s) }
 
 var (
 	varname = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*(?:/[a-zA-Z0-9_]+(?:,[a-zA-Z0-9_]+)*)?$`)
-	varcmd  = regexp.MustCompile(`\$\(HOST:.+?\)`)
-	varref  = regexp.MustCompile(`\$(?:\(HOST:.+?\)|[a-zA-Z_][a-zA-Z0-9_]*|\{[a-zA-Z_][a-zA-Z0-9_]*\})`)
+	varcmd  = regexp.MustCompile(`\$\(HOST:.+\)`)
+	varref  = regexp.MustCompile(`\$(?:\(HOST:.+\)|[a-zA-Z_][a-zA-Z0-9_]*|\{[a-zA-Z_][a-zA-Z0-9_]*\})`)
 )
 
 func evalslice(context string, values []string, cmdcache map[string]string, hostOnly bool, maps ...envmap) error {


### PR DESCRIPTION
I cannot think of the reason the original code used non-greedy
matching, given that YAML allows us to control the text of the
string quite strongly, and there is nothing we want to parse after the
closing parenthesis.

This fixes variables which use ) inside the shell command.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>