### PR TITLE
spread: fix overlooked googleNotFound->errGoogleNotFound rename

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -355,7 +355,7 @@ func (p *googleProvider) projectImages(project string) ([]googleImage, error) {
 	}
 
 	err := p.dofl("GET", "/compute/v1/projects/"+project+"/global/images?orderBy=creationTimestamp+desc", nil, &result, noPathPrefix)
-	if err == googleNotFound {
+	if err == errGoogleNotFound {
 	}
 	if err != nil {
 		return nil, &FatalError{fmt.Errorf("cannot retrieve Google images for project %q: %v", project, err)}


### PR DESCRIPTION
Trivial fix after https://github.com/snapcore/spread/pull/124