### PR TITLE
New option to select the number of disks on google instances

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -427,6 +427,27 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 	} else if system.Storage > 0 {
 		diskParams["diskSizeGb"] = int(system.Storage / gb)
 	}
+	disks := []googleParams{{
+			"autoDelete":       "true",
+			"boot":             "true",
+			"type":             "PERSISTENT",
+			"initializeParams": diskParams,
+		}}
+	if system.Disks > 10 {
+		return nil, &FatalError{fmt.Errorf("cannot allocate a Google server with more than 10 disks")}
+	} else if system.Disks < 0 {
+		return nil, &FatalError{fmt.Errorf("cannot allocate a Google server with negative number of disks")}
+	} else if system.Disks == 0 {
+		system.Disks = 1
+	}
+	for i := 1; i < system.Disks; i++ {
+		disks = append(disks, googleParams{
+				"autoDelete":       "true",
+				"boot":             "false",
+				"type":             "PERSISTENT",
+				"initializeParams": diskParams,
+			})
+	}
 
 	params := googleParams{
 		"name":        name,
@@ -438,12 +459,7 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 			}},
 			"network": "global/networks/default",
 		}},
-		"disks": []googleParams{{
-			"autoDelete":       "true",
-			"boot":             "true",
-			"type":             "PERSISTENT",
-			"initializeParams": diskParams,
-		}},
+		"disks": disks,
 		"metadata": googleParams{
 			"items": metadata,
 		},

--- a/spread/project.go
+++ b/spread/project.go
@@ -63,6 +63,7 @@ type Backend struct {
 	Plan     string
 	Location string
 	Storage  Size
+	Disks    int
 
 	Systems SystemsMap
 
@@ -121,6 +122,7 @@ type System struct {
 
 	// Only for Linode and Google so far.
 	Storage Size
+	Disks   int
 
 	// Only for Google so far.
 	SecureBoot bool `yaml:"secure-boot"`
@@ -552,6 +554,9 @@ func Load(path string) (*Project, error) {
 			}
 			if system.Storage == 0 {
 				system.Storage = backend.Storage
+			}
+			if system.Disks == 0 {
+				system.Disks = backend.Disks
 			}
 			if system.Plan == "" {
 				system.Plan = backend.Plan


### PR DESCRIPTION
The idea is to have a new option to allow to define the number of disks
for a machine in google backend servers.
The disks number can be set either at backend or at system level. 