### PR TITLE
chore: add super simple install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Spread
 
 [Why?](#why)  
 [The cascading matrix](#matrix)  
+[Install](#install)
 [Hello world](#hello-world)  
 [Environments](#environments)  
 [Variants](#variants)  
@@ -86,6 +87,16 @@ Any time you want to see how your matrix looks like and all the jobs that would
 run, use the `-list` option. It will show one entry per line in the format:
 ```
 backend:system:suite/task:variant
+```
+
+<a name="install"/>
+
+## Install
+
+Please install `spread` using Go install method:
+
+```shell
+go install github.com/snapcore/spread/cmd/spread@latest
 ```
 
 <a name="hello-world"/>


### PR DESCRIPTION
## What does this PR do?
It adds a simple command to install `spread` using Go tools.

## Why is it important?
It will help newcomers in installing the tool without having to look for other resources

