### PR TITLE
Support many external systems in parallel

### DIFF
--- a/spread/adhoc.go
+++ b/spread/adhoc.go
@@ -75,15 +75,21 @@ func (p *adhocProvider) Reuse(ctx context.Context, rsystem *ReuseSystem, system 
 	return s, nil
 }
 
-func (p *adhocProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *adhocProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	result, err := p.run(p.backend.Allocate, system, "")
 	if err != nil {
 		return nil, err
 	}
 	addr := result["ADDRESS"]
-	if addr == "" || strings.Contains(addr, " ") {
+	if len(strings.TrimSpace(addr)) == 0 {
 		return nil, fmt.Errorf("%s allocate must print ADDRESS=<SSH address> to stdout, got: %q", p.backend, addr)
 	}
+
+	allAddr := strings.Fields(addr)
+	if id >= len(allAddr) {
+		return nil, fmt.Errorf("not enough addresses defined for the required workers")
+	}
+	addr = allAddr[id]
 
 	s := &adhocServer{
 		p:       p,

--- a/spread/client.go
+++ b/spread/client.go
@@ -792,7 +792,7 @@ func (s *localScript) run() (stdout, stderr []byte, err error) {
 
 	var buf bytes.Buffer
 	buf.WriteString("set -eu\n")
-	buf.WriteString("ADDRESS() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ADDRESS>' || echo \"<ADDRESS $1>\"; }\n")
+	buf.WriteString("ADDRESS() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ADDRESS>' || echo \"<ADDRESS $@>\"; }\n")
 	buf.WriteString("FATAL() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<FATAL>' || echo \"<FATAL $@>\"; exit 213; }\n")
 	buf.WriteString("ERROR() { { set +xu; } 2> /dev/null; [ -z \"$1\" ] && echo '<ERROR>' || echo \"<ERROR $@>\"; exit 213; }\n")
 	buf.WriteString("MATCH() { { set +xu; } 2> /dev/null; local stdin=$(cat); echo $stdin | grep -q -E \"$@\" || { echo \"error: pattern not found on stdin:\\n$stdin\">&2; return 1; }; }\n")

--- a/spread/google.go
+++ b/spread/google.go
@@ -132,7 +132,7 @@ func (p *googleProvider) Reuse(ctx context.Context, rsystem *ReuseSystem, system
 	return s, nil
 }
 
-func (p *googleProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *googleProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	if err := p.checkKey(); err != nil {
 		return nil, err
 	}

--- a/spread/humbox.go
+++ b/spread/humbox.go
@@ -99,7 +99,7 @@ func (p *humboxProvider) Reuse(ctx context.Context, rsystem *ReuseSystem, system
 	return s, nil
 }
 
-func (p *humboxProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *humboxProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	if err := p.checkKey(); err != nil {
 		return nil, err
 	}

--- a/spread/linode.go
+++ b/spread/linode.go
@@ -212,7 +212,7 @@ func (p *linodeProvider) unreserve(s *linodeServer) {
 	p.mu.Unlock()
 }
 
-func (p *linodeProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *linodeProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	if err := p.checkKey(); err != nil {
 		return nil, err
 	}

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -93,7 +93,7 @@ func (p *lxdProvider) Reuse(ctx context.Context, rsystem *ReuseSystem, system *S
 	return s, nil
 }
 
-func (p *lxdProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *lxdProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	lxdimage, err := p.lxdImage(system)
 	if err != nil {
 		return nil, err

--- a/spread/provider.go
+++ b/spread/provider.go
@@ -13,7 +13,7 @@ var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 type Provider interface {
 	Backend() *Backend
-	Allocate(ctx context.Context, system *System) (Server, error)
+	Allocate(ctx context.Context, system *System, id int) (Server, error)
 	Reuse(ctx context.Context, rsystem *ReuseSystem, system *System) (Server, error)
 	GarbageCollect() error
 }

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -153,7 +153,7 @@ func qemuCmd(system *System, path string, mem, port int) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-func (p *qemuProvider) Allocate(ctx context.Context, system *System) (Server, error) {
+func (p *qemuProvider) Allocate(ctx context.Context, system *System, id int) (Server, error) {
 	// FIXME Find an available port more reliably.
 	port := 59301 + rand.Intn(99)
 	mem := 1500


### PR DESCRIPTION
This change allows the execution on the external systems in
parallel with the objective of speeding up the executions.

It can be done by all including the addresses desired and by defining
the number of workers for the system.

The allocate section does not need any change, just add all the
addresses in the SPREAD_EXTERNAL_ADDRESS var, like:
SPREAD_EXTERNAL_ADDRESS="localhost:8022 localhost:8023"