### PR TITLE
lxd: restart sshd service instead of killing it

### DIFF
--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -483,7 +483,7 @@ func (p *lxdProvider) tuneSSH(name string) error {
 	cmds := [][]string{
 		{"sed", "-i", `s/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/`, "/etc/ssh/sshd_config"},
 		{"/bin/bash", "-c", fmt.Sprintf("echo root:'%s' | chpasswd", p.options.Password)},
-		{"killall", "-HUP", "sshd"},
+		{"service", "sshd", "restart"},
 	}
 	for _, args := range cmds {
 		output, err := exec.Command("lxc", append([]string{"exec", name, "--"}, args...)...).CombinedOutput()


### PR DESCRIPTION
When testing with spread through the lxd-backend, it works fine against focal images, however when switching to jammy images which has a different configuration of openssh-server, the default method of just killing the ssh daemon results in spread not being able to connect through ssh after executing the commands in tuneSsh(). It seems the ssh daemon does not restart again.

Instead of killing the daemon, I changed the command to reload the daemon instead. This results in spread being able to correctly connect to ssh again.

