### PR TITLE
Repeat all

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,10 @@ the task fails.
 To do that there is an option `-repeat` which receives an integer indicating 
 the number of reexecutions to do, being 0 the default value.
 
+In case it is desired to repeat a set of tasks in the original order the option
+that can be used is `-repeat-all`, which receives an integer indicating
+the number of reexecutions to do, being 0 the default value.
+
 
 <a name="passwords">
 

--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -33,6 +33,7 @@ var (
 	artifacts      = flag.String("artifacts", "", "Where to store task artifacts")
 	seed           = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat         = flag.Int("repeat", 0, "Number of times to repeat each task")
+	repeatAll      = flag.Int("repeat-all", 0, "Number of times to repeat all the tasks")
 	garbageCollect = flag.Bool("gc", false, "Garbage collect backend resources when possible")
 )
 
@@ -95,6 +96,7 @@ func run() error {
 		Artifacts:      *artifacts,
 		Seed:           *seed,
 		Repeat:         *repeat,
+		RepeatAll:      *repeatAll,
 		GarbageCollect: *garbageCollect,
 	}
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -1060,6 +1060,13 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 
 	sort.Sort(jobsByName(jobs))
 
+	if options.RepeatAll > 0 {
+		jobsWithRepeat := make([]string, len(jobs) * (options.RepeatAll + 1))
+		for repeatAll := options.RepeatAll; repeatAll >= 0; repeatAll-- {
+			jobsWithRepeat = append(jobsWithRepeat, jobs...)
+		}
+		return jobsWithRepeat, nil
+	}
 	return jobs, nil
 }
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -1061,10 +1061,11 @@ func (p *Project) Jobs(options *Options) ([]*Job, error) {
 	sort.Sort(jobsByName(jobs))
 
 	if options.RepeatAll > 0 {
-		jobsWithRepeat := make([]string, len(jobs) * (options.RepeatAll + 1))
+		jobsWithRepeat := []*Job{}
 		for repeatAll := options.RepeatAll; repeatAll >= 0; repeatAll-- {
 			jobsWithRepeat = append(jobsWithRepeat, jobs...)
 		}
+
 		return jobsWithRepeat, nil
 	}
 	return jobs, nil

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -35,6 +35,7 @@ type Options struct {
 	Artifacts      string
 	Seed           int64
 	Repeat         int
+	RepeatAll      int
 	GarbageCollect bool
 }
 
@@ -152,13 +153,15 @@ func (r *Runner) loop() (err error) {
 		}
 
 		if !r.options.Discard {
-			logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
-			for _, job := range r.pending {
-				if job != nil {
-					r.add(&r.stats.TaskAbort, job)
+			for repeatAll := r.options.RepeatAll; repeatAll >= 0; repeatAll-- {
+				logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
+				for _, job := range r.pending {
+					if job != nil {
+						r.add(&r.stats.TaskAbort, job)
+					}
 				}
+				r.stats.log()
 			}
-			r.stats.log()
 		}
 		if !r.options.Reuse || r.options.Discard {
 			for len(r.servers) > 0 {

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -153,15 +153,13 @@ func (r *Runner) loop() (err error) {
 		}
 
 		if !r.options.Discard {
-			for repeatAll := r.options.RepeatAll; repeatAll >= 0; repeatAll-- {
-				logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
-				for _, job := range r.pending {
-					if job != nil {
-						r.add(&r.stats.TaskAbort, job)
-					}
+			logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
+			for _, job := range r.pending {
+				if job != nil {
+					r.add(&r.stats.TaskAbort, job)
 				}
-				r.stats.log()
 			}
+			r.stats.log()
 		}
 		if !r.options.Reuse || r.options.Discard {
 			for len(r.servers) > 0 {

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -153,13 +153,15 @@ func (r *Runner) loop() (err error) {
 		}
 
 		if !r.options.Discard {
-			logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
-			for _, job := range r.pending {
-				if job != nil {
-					r.add(&r.stats.TaskAbort, job)
+			for repeatAll := r.options.RepeatAll; repeatAll >= 0; repeatAll-- {
+				logNames(debugf, "Pending jobs after workers returned", r.pending, taskName)
+				for _, job := range r.pending {
+					if job != nil {
+						r.add(&r.stats.TaskAbort, job)
+					}
 				}
+				r.stats.log()
 			}
-			r.stats.log()
 		}
 		if !r.options.Reuse || r.options.Discard {
 			for len(r.servers) > 0 {


### PR DESCRIPTION
This option "-repeat-all" is used to repeat a set of tests. 
It is used to reproduce sporadic issues that are reproduced by running a sequence of tests.
See the following example to see the diff with -repeat option: 

spread -repeat 1 task1 task2
  . task1 
  . task1 
  . task2 
  . task2 

spread -repeat-all 1 task1 task2
  . task1 
  . task2
  . task1 
  . task2 
