### PR TITLE
Update the way used to detect a machine is ready in google

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -157,7 +157,7 @@ sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /et
 
 pkill -o -HUP sshd || true
 
-echo '` + googleReadyMarker + `' > /dev/ttyS2
+echo -e '\n` + googleReadyMarker + `\n' > /dev/console
 `
 
 const googleReadyMarker = "MACHINE-IS-READY"
@@ -523,7 +523,7 @@ func (p *googleProvider) waitServerBoot(ctx context.Context, s *googleServer) er
 	}
 	result.Next = "0"
 	for {
-		err = p.doz("GET", fmt.Sprintf("/instances/%s/serialPort?port=3&start=%s", s.d.Name, result.Next), nil, &result)
+		err = p.doz("GET", fmt.Sprintf("/instances/%s/serialPort?port=1&start=%s", s.d.Name, result.Next), nil, &result)
 		if err != nil {
 			printf("Cannot get console output for %s: %v", s, err)
 			return fmt.Errorf("cannot get console output for %s: %v", s, err)


### PR DESCRIPTION
On ARM servers it is not allowed to write to /dev/ttyS*, so the startup script fails to complete.

This implemerntation writes to console the Marker so it can be retrieved
by the serialPort API

This change has been validated for intel and arm and all the supported
systems and it works well.