### PR TITLE
Allow to add and remove tasks to execute in the filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ Just add this to the task or suite body:
 systems: [-ubuntu-14.04]
 ```
 
+And, what if you want to run in all the ubuntu systems, but skip a particular ubuntu-14.04?
+Just add this to the task or suite body:
+```
+systems: [ubuntu-*, -ubuntu-14.04]
+```
+
 Cascading also takes place for these settings - each level can
 add/remove/replace what the previous level defined, again with the ordering:
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -1219,14 +1219,14 @@ func evalstr(what string, strmaps ...strmap) ([]string, error) {
 			} else {
 				plain++
 			}
-			if delta > 0 && plain > 0 {
-				return nil, fmt.Errorf("%s specifies %s both in delta and plain format", strmap.context, what)
-			}
+			// Note: this code is commented to allow to specify add and remove as part of the filtering list
+			//if delta > 0 && plain > 0 {
+			//	return nil, fmt.Errorf("%s specifies %s both in delta and plain format", strmap.context, what)
+			//}
 			matches, err := matches(name, strmaps[:i+1]...)
 			if err != nil {
 				return nil, err
 			}
-
 			if add {
 				for _, match := range matches {
 					final[match] = true

--- a/tests/filters/checks/main/task.yaml
+++ b/tests/filters/checks/main/task.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [-ubuntu-22.04, ubuntu-2*.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task1.yaml
+++ b/tests/filters/checks/main/task1.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [ubuntu-*, -ubuntu-18.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task10.yaml
+++ b/tests/filters/checks/main/task10.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [ubuntu-*-arm-*]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task2.yaml
+++ b/tests/filters/checks/main/task2.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [ubuntu-*, -ubuntu-1*]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task3.yaml
+++ b/tests/filters/checks/main/task3.yaml
@@ -1,0 +1,8 @@
+summary: Test the filters for systems and backends work.
+
+backends: [lxd]
+
+systems: [-ubuntu-*, ubuntu-22.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task4.yaml
+++ b/tests/filters/checks/main/task4.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [-ubuntu-*, ubuntu-2*]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task5.yaml
+++ b/tests/filters/checks/main/task5.yaml
@@ -1,0 +1,8 @@
+summary: Test the filters for systems and backends work.
+
+backends: [lxd]
+
+systems: [-ubuntu-*, ubuntu-22.04, -ubuntu-22.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task6.yaml
+++ b/tests/filters/checks/main/task6.yaml
@@ -1,0 +1,8 @@
+summary: Test the filters for systems and backends work.
+
+backends: [lxd]
+
+systems: [-ubuntu-22.04, ubuntu-2*.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task7.yaml
+++ b/tests/filters/checks/main/task7.yaml
@@ -1,0 +1,8 @@
+summary: Test the filters for systems and backends work.
+
+backends: [google]
+
+systems: [ubuntu-*, -ubuntu-*arm*]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task8.yaml
+++ b/tests/filters/checks/main/task8.yaml
@@ -1,0 +1,8 @@
+summary: Test the filters for systems and backends work.
+
+backends: [lxd]
+
+systems: [-ubuntu-22.04, +ubuntu-22.04]
+
+execute: |
+    echo WORKS

--- a/tests/filters/checks/main/task9.yaml
+++ b/tests/filters/checks/main/task9.yaml
@@ -1,0 +1,6 @@
+summary: Test the filters for systems and backends work.
+
+systems: [-ubuntu-2*]
+
+execute: |
+    echo WORKS

--- a/tests/filters/spread.yaml
+++ b/tests/filters/spread.yaml
@@ -1,0 +1,25 @@
+project: spread
+
+backends:
+    lxd:
+        systems:
+            - ubuntu-16.04
+            - ubuntu-18.04
+            - ubuntu-20.04
+            - ubuntu-22.04
+
+    google:
+        systems:
+            - ubuntu-20.04-64
+            - ubuntu-20.04-arm-64
+            - ubuntu-22.04-64
+            - ubuntu-22.04-arm-64
+            - debian-sid-64
+
+path: /home/test
+
+suites:
+    checks/: 
+        summary: Verification tasks.
+
+# vim:ts=4:sw=4:et

--- a/tests/filters/task.yaml
+++ b/tests/filters/task.yaml
@@ -1,0 +1,85 @@
+summary: Test the MATCH function.
+
+prepare: |
+    if [ ! -f .spread-reuse.yaml ]; then
+        touch /run/spread-reuse.yaml
+        ln -s /run/spread-reuse.yaml .spread-reuse.yaml
+    fi
+
+restore: |
+    rm -f checks/main/task.yaml
+
+execute: |
+    cp checks/main/task1.yaml checks/main/task.yaml
+    # Match: lxd:ubuntu-16.04, lxd:ubuntu-20.04 and lxd:ubuntu-22.04
+    spread -list lxd:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 3
+    grep -q lxd:ubuntu-16.04:checks/main task.out
+    grep -q lxd:ubuntu-20.04:checks/main task.out
+    grep -q lxd:ubuntu-22.04:checks/main task.out
+
+    cp checks/main/task2.yaml checks/main/task.yaml
+    # Match: lxd:ubuntu-20.04 and lxd:ubuntu-22.04
+    spread -list lxd:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 2
+    grep -q lxd:ubuntu-20.04:checks/main task.out
+    grep -q lxd:ubuntu-22.04:checks/main task.out
+
+    cp checks/main/task3.yaml checks/main/task.yaml
+    # Match: lxd:ubuntu-22.04
+    spread -list lxd:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 1
+    grep -q lxd:ubuntu-22.04:checks/main task.out
+
+    cp checks/main/task4.yaml checks/main/task.yaml
+    # Match: lxd:ubuntu-20.04, lxd:ubuntu-22.04
+    # Match: All the 5 google systems
+    spread -list checks/main &> task.out 
+    test "$(cat task.out | wc -l)" = 7
+    grep -q google:ubuntu-20.04-64:checks/main task.out
+    grep -q google:debian-sid-64:checks/main task.out
+    grep -q google:ubuntu-20.04-arm-64:checks/main task.out
+    grep -q lxd:ubuntu-20.04:checks/main task.out
+
+    cp checks/main/task5.yaml checks/main/task.yaml
+    # No Matches
+    spread -list lxd:checks/main 2>&1 | grep -q "error: nothing matches provider filter"
+
+    cp checks/main/task6.yaml checks/main/task.yaml
+    # Match: All the lxd systems
+    spread -list lxd:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 4
+    grep -q lxd:ubuntu-20.04:checks/main task.out
+    grep -q lxd:ubuntu-22.04:checks/main task.out
+
+    cp checks/main/task7.yaml checks/main/task.yaml
+    # Match: google:ubuntu-20.04 and google:ubuntu-22.04
+    spread -list google:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 2
+    grep -q google:ubuntu-20.04-64:checks/main task.out
+    grep -q google:ubuntu-22.04-64:checks/main task.out
+
+    cp checks/main/task8.yaml checks/main/task.yaml
+    # Match: All the lxd systems
+    spread -list lxd:checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 4
+    grep -q lxd:ubuntu-16.04:checks/main task.out
+    grep -q lxd:ubuntu-22.04:checks/main task.out
+
+    cp checks/main/task9.yaml checks/main/task.yaml
+    # Match: All the ubuntu 1* and debian systems
+    spread -list checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 3
+    grep -q lxd:ubuntu-16.04:checks/main task.out
+    grep -q lxd:ubuntu-18.04:checks/main task.out
+    grep -q google:debian-sid-64:checks/main task.out
+
+    cp checks/main/task10.yaml checks/main/task.yaml
+    # Match: All the arm systems
+    spread -list checks/main &> task.out
+    test "$(cat task.out | wc -l)" = 2
+    grep -q google:ubuntu-20.04-arm-64:checks/main task.out
+    grep -q google:ubuntu-22.04-arm-64:checks/main task.out
+
+debug: |
+    cat task.out || true


### PR DESCRIPTION
With this change it is possible to specify by adding and removing in the
filters.

This is needed for example when we need to run in all the ubuntu but
need to skip a particular one (like the arm-64 ones)

The change also includes a test to validate many filtering different
scenarios