### PR TITLE
client: use kernel `boot_id` to detect if a system got rebooted

### DIFF
--- a/spread/client_test.go
+++ b/spread/client_test.go
@@ -26,6 +26,6 @@ func (s *clientSuite) TestDialOnReboot(c *C) {
 	spread.SetWarnTimeout(cli, 50*time.Millisecond)
 	spread.SetKillTimeout(cli, 100*time.Millisecond)
 
-	err := spread.DialOnReboot(cli, time.Time{})
+	err := spread.DialOnReboot(cli, "")
 	c.Check(err, ErrorMatches, "kill-timeout reached after mock-job reboot request")
 }

--- a/spread/export_test.go
+++ b/spread/export_test.go
@@ -17,8 +17,8 @@ func MockClient() *Client {
 	}
 }
 
-func DialOnReboot(cli *Client, prevUptime time.Time) error {
-	return cli.dialOnReboot(prevUptime)
+func DialOnReboot(cli *Client, prevBootID string) error {
+	return cli.dialOnReboot(prevBootID)
 }
 
 func SetKillTimeout(cli *Client, killTimeout time.Duration) {


### PR DESCRIPTION
This commit changes the code that detects if a reboot has happend based on the kernel `boot_id`. This is based on the idea from Valentin in PR#143 but slightly simplified as it will not parse the uuid but just tread as an opaque string.