### PR TITLE
snapcraft.yaml: improve version,base and plugs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,13 +15,13 @@ grade: stable
 base: core22
 
 plugs:
-  spread-config:
+  dot-spread:
     interface: personal-files
     read:
       - $HOME/.spread
     write:
       - $HOME/.spread
-  gcloud-config:
+  dot-gcloud:
     interface: personal-files
     read:
       - $HOME/.config/gcloud
@@ -32,8 +32,8 @@ apps:
           - home
           - network
           - network-bind
-          - spread-config
-          - gcloud-config
+          - dot-spread
+          - dot-gcloud
 
 parts:
     spread:


### PR DESCRIPTION
This PR adds three patches, I'm happy to propose individual PRs instead if that is preferred:
1. move to base core22
2. generate version number based on date and git hash
3. provide spread and gcloud config personal-files plugs 

I'm happy to tweak things as needed, especially the version number seems to be something that people have different opinions about.