### PR TITLE
qemu: allow specifying the machine type

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -139,6 +139,10 @@ type System struct {
 
 	Priority OptionalInt
 	Manual   bool
+
+	// Type of machine emulated, only for qemu. Defaults to "pc", which is
+	// the QEMU default for x86_64
+	MachineType string `yaml:"machine-type"`
 }
 
 func (system *System) String() string { return system.Backend + ":" + system.Name }

--- a/spread/qemu.go
+++ b/spread/qemu.go
@@ -121,6 +121,13 @@ func biosPath(biosName string) (string, error) {
 	return "", fmt.Errorf("cannot find bios path for %q", biosName)
 }
 
+func machineType(system *System) string {
+	if system.MachineType == "" {
+		return "pc"
+	}
+	return system.MachineType
+}
+
 func qemuCmd(system *System, path string, mem, port int) (*exec.Cmd, error) {
 	serial := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+100)
 	monitor := fmt.Sprintf("telnet:127.0.0.1:%d,server,nowait", port+200)
@@ -133,6 +140,7 @@ func qemuCmd(system *System, path string, mem, port int) (*exec.Cmd, error) {
 		"-net", fwd,
 		"-serial", serial,
 		"-monitor", monitor,
+		"-M", machineType(system),
 		path)
 	if os.Getenv("SPREAD_QEMU_GUI") != "1" {
 		cmd.Args = append([]string{cmd.Args[0], "-nographic"}, cmd.Args[1:]...)


### PR DESCRIPTION
This allows QEMU machine types to be used other than the default "pc", such as "q35". Valid alternative machine types can be identified with the `qemu-system-x86_64 -M help` command.

This is useful for testing images for embedded systems which may not support the "pc" QEMU machine type, or require features from "q35" or other types.