### PR TITLE
qemu: add options to enable virtio device backends

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -143,6 +143,10 @@ type System struct {
 	// Specify that the disk should be attached using the "virtio" backend
 	// in QEMU. Only supported by the qemu backend.
 	VirtioDisk bool `default:"false" yaml:"virtio-disk"`
+
+	// Specify that the network interface should be attached using the
+	// "virtio" backend in QEMU. Only supported by the qemu backend.
+	VirtioNet bool `default:"false" yaml:"virtio-net"`
 }
 
 func (system *System) String() string { return system.Backend + ":" + system.Name }


### PR DESCRIPTION
In some cases, the virtio backend is needed for the disk. This adds the boolean option "virtio-disk", which specifies if the disk should be attached via the virtio backend when true, or using the default backend when false.

Similarly, in some cases the virtio backend is needed for the network. This also adds the option "virtio-net", which specifies if the network interface should be attached via the virtio backend when true, or using the default e1000 backend when false.

This is useful for testing images with stripped-down kernels which do not provide drivers for the default network and storage backends, and only support virtio.