### PR TITLE
spread: add device backend configuration support to QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,30 @@ adt-buildvm-ubuntu-cloud
 ```
 When done move the downloaded image into the location described above.
 
+The QEMU backend will normally create the VM with the default device
+backends. The backends for the network and drive devices can be overriden
+using the `device-backends` map in the systems configuration, and can be
+set to any string which will then be passed to QEMU. Currently, only
+setting the backend for the network and drive interfaces are supported.
+
+For example, to set the drive backend to `virtio` and the network backend
+to `virtio-net-pci`, the following system configuration could be used:
+
+_$PROJECT/spread.yaml_
+```
+backends:
+    qemu:
+        systems:
+            - ubuntu-16.04:
+                username: ubuntu
+                password: ubuntu
+                device-backends:
+                    drive: virtio
+                    network: virtio-net-pci
+```
+
+Care must be taken when setting these values as they are passed verbatim
+to the QEMU instance, without checking if the backend is supported by QEMU.
 
 <a name="google"/>
 

--- a/spread/project.go
+++ b/spread/project.go
@@ -139,6 +139,11 @@ type System struct {
 
 	Priority OptionalInt
 	Manual   bool
+
+	// Specify the backends to use for devices in the system under test.
+	// The specific effect of this will depend on the backend used for
+	// this system.
+	DeviceBackends DeviceBackendsMap `yaml:"device-backends"`
 }
 
 func (system *System) String() string { return system.Backend + ":" + system.Name }
@@ -1363,3 +1368,5 @@ func sortedKeys(m map[string]bool) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+type DeviceBackendsMap map[string]string

--- a/spread/project.go
+++ b/spread/project.go
@@ -143,6 +143,8 @@ type System struct {
 	// Specify the backends to use for devices in the system under test.
 	// The specific effect of this will depend on the backend used for
 	// this system.
+	// Currently, only the qemu backend supports this, and only for the
+	// drive and network device drivers.
 	DeviceBackends DeviceBackendsMap `yaml:"device-backends"`
 }
 

--- a/spread/project_test.go
+++ b/spread/project_test.go
@@ -74,6 +74,9 @@ backends:
    - system-2:
       plan: plan-for-2
    - system-3:
+   - system-4:
+      device-backends:
+        test-device: test-backend
 suites:
  tests/:
   summary: mock tests
@@ -91,6 +94,8 @@ suites:
 	c.Check(backend.Systems["system-1"].Plan, Equals, "global-plan")
 	c.Check(backend.Systems["system-2"].Plan, Equals, "plan-for-2")
 	c.Check(backend.Systems["system-3"].Plan, Equals, "global-plan")
+	c.Check(len(backend.Systems["system-4"].DeviceBackends), Equals, 1)
+	c.Check(backend.Systems["system-4"].DeviceBackends["test-device"], Equals, "test-backend")
 }
 
 func (s *projectSuite) TestOptionalInt(c *C) {


### PR DESCRIPTION
This adds the `device-backends` configuration option, which allows the user  to specify which backends for specific devices the system should use. This has no effect on its own, as the implementation is system backend specific; only the QEMU backend has been enabled with this functionality.

For the QEMU backend, this allows the user to specify which backend should be used for the disk and network devices. Currently, only the "network" and "disk" devices are able to be specified. If they are not specified, QEMU will use the default backends ("e1000" and "none", respectively).

This is useful for testing images with stripped-down kernels which do not provide drivers for the default network and storage backends, and only support other drivers (for example only virtio). 

