### PR TITLE
spread reports

### DIFF
--- a/cmd/spread/main.go
+++ b/cmd/spread/main.go
@@ -34,6 +34,7 @@ var (
 	seed           = flag.Int64("seed", 0, "Seed for job order permutation")
 	repeat         = flag.Int("repeat", 0, "Number of times to repeat each task")
 	garbageCollect = flag.Bool("gc", false, "Garbage collect backend resources when possible")
+	report         = flag.Bool("report", false, "Create xml and json reports")
 )
 
 func main() {
@@ -96,6 +97,7 @@ func run() error {
 		Seed:           *seed,
 		Repeat:         *repeat,
 		GarbageCollect: *garbageCollect,
+		Report:         *report,
 	}
 
 	project, err := spread.Load(".")

--- a/spread.yaml
+++ b/spread.yaml
@@ -31,9 +31,11 @@ backends:
                 password: ubuntu
 
 exclude:
+    - .git
     - .spread-reuse.yaml
     - tests/.spread-reuse.yaml
     - $CACHE_DISABLED
+    - "*.snap"
 
 path: /home/test/src/github.com/snapcore/spread
 

--- a/spread/report.go
+++ b/spread/report.go
@@ -1,0 +1,220 @@
+package spread
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+)
+
+const (
+	failed  = "failed"
+	aborted = "aborted"
+	passed  = "passed"
+)
+
+type ResultsTestSuite struct {
+	Name    string             `xml:"name,attr" json:"name,attr"`
+	Passed  int                `xml:"passed,attr" json:"passed,attr"`
+	Failed  int                `xml:"failed,attr" json:"failed,attr"`
+	Aborted int                `xml:"aborted,attr" json:"aborted,attr"`
+	Total   int                `xml:"total,attr" json:"total,attr"`
+	Tests   []*ResultsTestCase `xml:"test,omitempty" json:"tests,omitempty"`
+}
+
+func NewResultsTestSuite(name string) *ResultsTestSuite {
+	return &ResultsTestSuite{
+		Name:    name,
+		Passed:  0,
+		Failed:  0,
+		Aborted: 0,
+		Total:   0,
+		Tests:   []*ResultsTestCase{},
+	}
+}
+
+func (ts *ResultsTestSuite) addTest(test *ResultsTestCase) {
+	for _, t := range ts.Tests {
+		// The test case has failed and now it is aborted
+		// in this case it counts as aborted and not as failed
+		// The total is not changed in this scenario
+		if test.Name == t.Name {
+			if len(test.Failures) > 0 {
+				if test.Failures[0].Result == aborted {
+					ts.Aborted += 1
+					ts.Failed -= 1
+					t.Result = aborted
+				}
+				t.Failures = append(t.Failures, test.Failures[0])
+			}
+			return
+		}
+	}
+
+	if len(test.Failures) > 0 {
+		if test.Failures[0].Result == failed {
+			ts.Failed += 1
+			test.Result = failed
+		} else {
+			ts.Aborted += 1
+			test.Result = aborted
+		}
+	} else {
+		ts.Passed += 1
+		test.Result = passed
+	}
+	ts.Total += 1
+	ts.Tests = append(ts.Tests, test)
+}
+
+type ResultsTestCase struct {
+	Name     string `xml:"name,attr" json:"name,attr"`
+	suite    string
+	Result   string            `xml:"result,attr" json:"result,attr"`
+	Failures []*ResultsFailure `xml:"failure,omitempty" json:"failure,omitempty"`
+}
+
+func NewResultsTestCase(testName string, backend string, system string, suiteName string) *ResultsTestCase {
+	name := fmt.Sprintf("%s:%s:%s/%s", backend, system, suiteName, testName)
+	return &ResultsTestCase{
+		Name:     name,
+		suite:    suiteName,
+		Failures: []*ResultsFailure{},
+	}
+}
+
+type ResultsFailure struct {
+	Info   string `xml:"info" json:"info"`
+	Result string `xml:"result" json:"result"`
+}
+
+func NewResultsFailure(info string, Result string) *ResultsFailure {
+	return &ResultsFailure{
+		Info:   info,
+		Result: Result,
+	}
+}
+
+type ResultsReport struct {
+	Passed  int                 `xml:"passed,attr" json:"passed,attr"`
+	Failed  int                 `xml:"failed,attr" json:"failed,attr"`
+	Aborted int                 `xml:"aborted,attr" json:"aborted,attr"`
+	Total   int                 `xml:"total,attr" json:"total,attr"`
+	Suites  []*ResultsTestSuite `xml:"testsuite,omitempty" json:"testsuites,omitempty"`
+}
+
+func CreateResultsReport(results stats) error {
+	report := &ResultsReport{
+		Suites: []*ResultsTestSuite{},
+	}
+	report.complete(results)
+	return report.write()
+}
+
+func (r *ResultsReport) addTests(testsList []*Job, result string, stage string) {
+	for _, job := range testsList {
+		// task names look like paths (eg suite/foo/bar/job)
+		name := taskName(job)
+		suiteName := filepath.Dir(name)
+		testName := filepath.Base(name)
+
+		if result == failed {
+			r.addFailedTest(suiteName, job.Backend.Name, job.System.Name, testName, stage)
+		} else if result == aborted {
+			r.addAbortedTest(suiteName, job.Backend.Name, job.System.Name, testName)
+		} else {
+			r.addPassedTest(suiteName, job.Backend.Name, job.System.Name, testName)
+		}
+	}
+}
+
+func (r *ResultsReport) complete(results stats) {
+	r.addTests(results.TaskPrepareError, failed, preparing)
+	r.addTests(results.TaskError, failed, executing)
+	r.addTests(results.TaskRestoreError, failed, restoring)
+	r.addTests(results.TaskAbort, aborted, "")
+	r.addTests(results.TaskDone, passed, "")
+
+	for _, s := range r.Suites {
+		r.Total += s.Total
+		r.Aborted += s.Aborted
+		r.Failed += s.Failed
+		r.Passed += s.Passed
+	}
+}
+
+func (r *ResultsReport) getSuite(suiteName string) *ResultsTestSuite {
+	for _, s := range r.Suites {
+		if s.Name == suiteName {
+			return s
+		}
+	}
+	suite := NewResultsTestSuite(suiteName)
+	r.Suites = append(r.Suites, suite)
+	return suite
+}
+
+func (r ResultsReport) write() error {
+	err := r.writeXML("spread_report.xml")
+	if err != nil {
+		return err
+	}
+	err = r.writeJSON("spread_report.json")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ResultsReport) writeXML(filename string) error {
+	bytes, err := xml.MarshalIndent(r, "", "\t")
+	if err != nil {
+		return fmt.Errorf("cannot indent the Results report: %v", err)
+	}
+
+	err = ioutil.WriteFile(filename, bytes, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot write Results report to %s file: %v", filename, err)
+	}
+
+	return nil
+}
+
+func (r ResultsReport) writeJSON(filename string) error {
+	bytes, err := json.MarshalIndent(r, "", "    ")
+	if err != nil {
+		return fmt.Errorf("cannot indent the JSONUnit report: %v", err)
+	}
+
+	err = ioutil.WriteFile(filename, bytes, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot write JSONUnit report to %s file: %v", filename, err)
+	}
+
+	return nil
+}
+
+func (r *ResultsReport) addTest(test *ResultsTestCase) {
+	suite := r.getSuite(test.suite)
+	suite.addTest(test)
+}
+
+func (r *ResultsReport) addFailedTest(suiteName string, backend string, system string, testName string, stage string) {
+	testcase := NewResultsTestCase(testName, backend, system, suiteName)
+	failure := NewResultsFailure(stage, failed)
+	testcase.Failures = append(testcase.Failures, failure)
+	r.addTest(testcase)
+}
+
+func (r *ResultsReport) addAbortedTest(suiteName string, backend string, system string, testName string) {
+	testcase := NewResultsTestCase(testName, backend, system, suiteName)
+	failure := NewResultsFailure(executing, aborted)
+	testcase.Failures = append(testcase.Failures, failure)
+	r.addTest(testcase)
+}
+
+func (r *ResultsReport) addPassedTest(suiteName string, backend string, system string, testName string) {
+	testcase := NewResultsTestCase(testName, backend, system, suiteName)
+	r.addTest(testcase)
+}

--- a/spread/runner.go
+++ b/spread/runner.go
@@ -22,6 +22,7 @@ import (
 type Options struct {
 	Password       string
 	Filter         Filter
+	Args           string
 	Reuse          bool
 	ReusePid       int
 	Debug          bool
@@ -36,6 +37,7 @@ type Options struct {
 	Seed           int64
 	Repeat         int
 	GarbageCollect bool
+	Report         bool
 }
 
 type Runner struct {
@@ -159,6 +161,7 @@ func (r *Runner) loop() (err error) {
 				}
 			}
 			r.stats.log()
+			r.createReports()
 		}
 		if !r.options.Reuse || r.options.Discard {
 			for len(r.servers) > 0 {
@@ -1023,6 +1026,15 @@ func (r *Runner) reuseServer(backend *Backend, system *System) *Client {
 		return client
 	}
 	return nil
+}
+
+func (r *Runner) createReports() {
+	if r.options.Report {
+		err := CreateResultsReport(r.stats)
+		if err != nil {
+			printf("Failed to create results reports: %v", err)
+		}
+	}
 }
 
 type stats struct {

--- a/tests/report/spread.yaml
+++ b/tests/report/spread.yaml
@@ -1,0 +1,39 @@
+project: spread
+
+backends:
+    lxd:
+        systems:
+        - ubuntu-16.04
+
+path: /root/test
+
+suites:
+    tests/tests1/:
+        summary: Test suite 1 for spread
+        prepare: |
+            echo "Preparing tests1 suite"
+        restore: |
+            echo "Restoring tests1 suite"
+
+    tests/tests2/:
+        summary: Test suite 2 for spread
+        prepare: |
+            echo "Preparing tests2 suite"
+            exit 1
+        restore: |
+            echo "Restoring tests2 suite"
+
+    tests/tests3/:
+        summary: Test suite 3 for spread
+        prepare: |
+            echo "Preparing tests3 suite"
+        restore: |
+            echo "Restoring tests3 suite"
+            exit 1
+
+    tests/tests4/:
+        summary: Test suite 4 for spread
+        prepare: |
+            echo "Preparing tests1 suite"
+        restore: |
+            echo "Restoring tests1 suite"

--- a/tests/report/task.yaml
+++ b/tests/report/task.yaml
@@ -1,0 +1,94 @@
+summary: Test the reports
+
+prepare: |
+    if [ ! -f .spread-reuse.yaml ]; then
+        touch /run/spread-reuse.yaml
+        ln -s /run/spread-reuse.yaml .spread-reuse.yaml
+    fi
+
+execute: |
+    ! test -e spread_report.xml
+    ! test -e spread_report.json
+
+    # For tests1 these are the expected results for the reports
+    # Total: 5 Passed: 2 Aborted: 1 Failed: 2
+    # tests1/t11 -> Passed
+    # tests1/t12 -> Passed
+    # tests1/t13 -> Failed
+    # tests1/t14 -> Aborted
+    # tests1/t15 -> Failed (also failes debug section)
+
+    spread -v -reuse -resend -report lxd:ubuntu-16.04:tests/tests1/ || true
+
+    jq -r '.testsuites[0].total' spread_report.json | MATCH 5
+    jq -r '.testsuites[0].passed' spread_report.json | MATCH 2
+    jq -r '.testsuites[0].aborted' spread_report.json | MATCH 1
+    jq -r '.testsuites[0].failed' spread_report.json | MATCH 2
+    MATCH 'testsuite name="tests/tests1" passed="2" failed="2" aborted="1" total="5"' < spread_report.xml
+    MATCH 'test name="lxd:ubuntu-16.04:tests/tests1/t14" result="aborted"' < spread_report.xml
+    MATCH 'test name="lxd:ubuntu-16.04:tests/tests1/t13" result="failed"' < spread_report.xml
+    MATCH 'test name="lxd:ubuntu-16.04:tests/tests1/t11" result="passed"' < spread_report.xml
+
+    # For tests2 these are the expected results for the reports
+    # Total: 2 Passed: 0 Aborted: 2 Failed: 0
+    # The test suite fails to prepare so the tests are aborted
+    # tests2/t21 -> Aborted
+    # tests2/t22 -> Aborted
+
+    spread -v -reuse -resend -report lxd:ubuntu-16.04:tests/tests2/ || true
+
+    jq -r '.testsuites[0].total' spread_report.json | MATCH 2
+    jq -r '.testsuites[0].passed' spread_report.json | MATCH 0
+    jq -r '.testsuites[0].aborted' spread_report.json | MATCH 2
+    jq -r '.testsuites[0].failed' spread_report.json | MATCH 0
+    MATCH 'testsuite name="tests/tests2" passed="0" failed="0" aborted="2" total="2"' < spread_report.xml
+    MATCH 'test name="lxd:ubuntu-16.04:tests/tests2/t21" result="aborted' < spread_report.xml
+    MATCH 'test name="lxd:ubuntu-16.04:tests/tests2/t22" result="aborted' < spread_report.xml
+
+    # For tests3 these are the expected results for the reports
+    # Total: 3 Passed: 1 Aborted: 1 Failed: 1
+    # The test suite fails to restore so the tests are not affected
+    # tests3/t31 -> Passed
+    # tests3/t32 -> Failed
+    # tests3/t33 -> Aborted (also fails restore) (it is executed at last)
+
+    spread -v -reuse -resend -report lxd:ubuntu-16.04:tests/tests3/ || true
+
+    jq -r '.testsuites[0].total' spread_report.json | MATCH 3
+    jq -r '.testsuites[0].passed' spread_report.json | MATCH 1
+    jq -r '.testsuites[0].aborted' spread_report.json | MATCH 1
+    jq -r '.testsuites[0].failed' spread_report.json | MATCH 1
+    MATCH 'testsuite name="tests/tests3" passed="1" failed="1" aborted="1" total="3"' < spread_report.xml
+
+    # For tests4 these are the expected results for the reports
+    # Total: 4 Passed: 1 Aborted: 2 Failed: 1
+    # The test 42 (which is the second to be executed) fails during restore,
+    # so the tests 43 and 44 are aborted.
+    # tests4/t41 -> Passed
+    # tests4/t42 -> Failed (fails during restore)
+    # tests4/t42 -> Aborted
+    # tests4/t43 -> Aborted
+
+    spread -v -reuse -resend -report lxd:ubuntu-16.04:tests/tests4/ || true
+
+    jq -r '.testsuites[0].total' spread_report.json | MATCH 4
+    jq -r '.testsuites[0].passed' spread_report.json | MATCH 1
+    jq -r '.testsuites[0].aborted' spread_report.json | MATCH 2
+    jq -r '.testsuites[0].failed' spread_report.json | MATCH 1
+    MATCH 'testsuite name="tests/tests4" passed="1" failed="1" aborted="2" total="4"' < spread_report.xml
+
+    # The order in the report is: failed, aborted and passed
+    jq -r '.testsuites[0].tests[0].failure[0].info' spread_report.json | MATCH restoring
+    jq -r '.testsuites[0].tests[0].failure[0].result' spread_report.json | MATCH failed
+    jq -r '.testsuites[0].tests[1].failure[0].info' spread_report.json | MATCH executing
+    jq -r '.testsuites[0].tests[1].failure[0].result' spread_report.json | MATCH aborted
+
+    # Check the reports are not generated when th option -report is not used
+    rm spread_report.xml spread_report.json
+    spread -v -reuse -resend lxd:ubuntu-16.04:tests/tests4/ || true
+    ! test -e spread_report.xml
+    ! test -e spread_report.json
+
+debug: |
+    cat .spread-reuse.yaml || true
+    cat task.out || true

--- a/tests/report/tests/tests1/t11/task.yaml
+++ b/tests/report/tests/tests1/t11/task.yaml
@@ -1,0 +1,7 @@
+summary: test
+
+priority: 1000
+
+execute: |
+    echo works
+

--- a/tests/report/tests/tests1/t12/task.yaml
+++ b/tests/report/tests/tests1/t12/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 1000
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests1/t13/task.yaml
+++ b/tests/report/tests/tests1/t13/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 1000
+
+prepare: |
+    echo works
+
+execute: |
+    exit 1
+
+restore: |
+    echo works

--- a/tests/report/tests/tests1/t14/task.yaml
+++ b/tests/report/tests/tests1/t14/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 1000
+
+prepare: |
+    exit 1
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests1/t15/task.yaml
+++ b/tests/report/tests/tests1/t15/task.yaml
@@ -1,0 +1,15 @@
+summary: test
+
+priority: 1000
+
+prepare: |
+    echo works
+
+execute: |
+    exit 1
+
+debug: |
+    exit 1
+
+restore: |
+    echo works

--- a/tests/report/tests/tests2/t21/task.yaml
+++ b/tests/report/tests/tests2/t21/task.yaml
@@ -1,0 +1,10 @@
+summary: test
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests2/t22/task.yaml
+++ b/tests/report/tests/tests2/t22/task.yaml
@@ -1,0 +1,10 @@
+summary: test
+
+prepare: |
+    echo works
+
+execute: |
+    exit 1
+
+restore: |
+    echo works

--- a/tests/report/tests/tests3/t31/task.yaml
+++ b/tests/report/tests/tests3/t31/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 5
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests3/t32/task.yaml
+++ b/tests/report/tests/tests3/t32/task.yaml
@@ -1,0 +1,10 @@
+summary: test
+
+prepare: |
+    echo works
+
+execute: |
+    exit 1
+
+restore: |
+    echo works

--- a/tests/report/tests/tests3/t33/task.yaml
+++ b/tests/report/tests/tests3/t33/task.yaml
@@ -1,0 +1,10 @@
+summary: test
+
+prepare: |
+    exit 1
+
+execute: |
+    echo works
+
+restore: |
+    exit 1

--- a/tests/report/tests/tests4/t41/task.yaml
+++ b/tests/report/tests/tests4/t41/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 1000
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests4/t42/task.yaml
+++ b/tests/report/tests/tests4/t42/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 10
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    exit 1

--- a/tests/report/tests/tests4/t43/task.yaml
+++ b/tests/report/tests/tests4/t43/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 5
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works

--- a/tests/report/tests/tests4/t44/task.yaml
+++ b/tests/report/tests/tests4/t44/task.yaml
@@ -1,0 +1,12 @@
+summary: test
+
+priority: 5
+
+prepare: |
+    echo works
+
+execute: |
+    echo works
+
+restore: |
+    echo works


### PR DESCRIPTION
This new functionality is used to create standard result reports which can be integrated with other tools to display and query

This include:
  . a new -report option
  . new spread_report.xml
  . new  spread_report.json
  . new test