### PR TITLE
Add custom GH action for installing and configuring Spread

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,3 +26,19 @@ jobs:
           for r in .spread-reuse.*.yaml; do
             spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
           done
+
+  action-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Spread
+        uses: ./
+        id: install-spread
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Test the spread installation
+        run: |
+          echo "Spread path: ${{ steps.install-spread.outputs.path }}"
+          spread -list

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Spread
 [AdHoc backend](#adhoc)  
 [More on parallelism](#parallelism)  
 [Repacking and delta uploads](#repacking)  
+[GitHub Action](#github-action)
 
 <a name="why"/>
 
@@ -1175,3 +1176,29 @@ prepare: |
 
 The `rename` and `exclude` settings used above ensure that the tarball that goes
 into `repack` looks like the one offered by GitHub.
+
+<a name="github-action"/>
+
+## GitHub action
+
+To facilitate using Spread within GitHub workflows, this repository offers a
+custom GitHub action to install and configure Spread on a GitHub runner.
+
+### Usage
+
+```yaml
+- uses: snapcore/spread@master
+```
+
+#### Inputs
+
+##### `ref`
+
+The branch, tag or commit sha of the Spread repository is to be checked out and
+from where the Spread binary will be built. The default value is `master`.
+
+```yaml
+- uses: snapcore/spread@master
+  with:
+    ref: master
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: 'Setup Spread'
+description: 'Install and configure Spread on the runner'
+inputs:
+  ref:
+    description: 'Branch, tag or SHA to checkout'
+    required: true
+    default: 'master'
+outputs:
+  path:
+    description: "Path to the Spread binary"
+    value: ${{ steps.get-path.outputs.spread-path }}
+runs:
+  using: "composite"
+  steps:
+    - run: echo "CHECKOUT_PATH=_spread-${{ github.job	 }}" >> $GITHUB_ENV
+      shell: bash
+
+    - uses: actions/checkout@v3
+      with:
+        repository: 'snapcore/spread'
+        path: ${{ env.CHECKOUT_PATH }}
+        ref: ${{ inputs.ref }}
+
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: ${{ env.CHECKOUT_PATH }}/go.mod
+
+    - name: Build and run spread
+      working-directory: ${{ env.CHECKOUT_PATH }}
+      run: go install ./...
+      shell: bash
+
+    - id: get-path
+      run: echo "spread-path=$(which spread)" >> $GITHUB_OUTPUT
+      shell: bash


### PR DESCRIPTION
Given that Spread is being used in multiple GitHub repositories to assist with the testing of software, this PR introduces a custom composite GitHub action to simplify and streamline the installation and configuration of the Spread binary on the GitHub runners.

What's included:
 - a new `action.yml` file where the composite GH action is defined. It accepts the Spread repo branch/tag/sha to be checked out (default is `master`). It also outputs the final path of the `spread` binary on the GH runner.
 - an additional step to the existing test workflow, to make sure the new action behaves well
 - an update to the README.md file to document this new GitHub action

Example of a successful run: https://github.com/cjdcordeiro/spread/actions/runs/5879643153/job/15944157818