### PR TITLE
fix: runner: ignore unknown file types and sockets (fixes #176)

### DIFF
--- a/spread/runner.go
+++ b/spread/runner.go
@@ -277,7 +277,7 @@ func (r *Runner) prepareContent() (err error) {
 		return fmt.Errorf("cannot remove temporary content file: %v", err)
 	}
 
-	args := []string{"c", "--exclude=.spread-reuse.*"}
+	args := []string{"c", "--exclude=.spread-reuse.*", "--warning=no-file-ignored"}
 	if r.project.Repack == "" {
 		args[0] = "cz"
 	}


### PR DESCRIPTION
Do not pack unknown file types + UNIX domain sockets when creating the tarball.

See #176 for a detailed description of the problem.