### PR TITLE
Fix LXD cloud init images and add profiles

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -125,6 +125,9 @@ type System struct {
 	// Only for Google so far.
 	SecureBoot bool `yaml:"secure-boot"`
 
+	// List of profiles, only for LXD
+	Profiles []string
+
 	// Supported are {"uefi",""}, only for qemu so far.
 	Bios string
 	// Request a specific CPU family, e.g. "Intel Skylake" The

--- a/tests/lxd/spread.yaml
+++ b/tests/lxd/spread.yaml
@@ -3,7 +3,7 @@ project: spread
 backends:
     lxd:
         systems:
-            - ubuntu-16.04
+            - ubuntu-24.04
 
 path: /home/test
 


### PR DESCRIPTION
LXD profiles are useful to define the characteristic of the LXD container, and also to use privileged containers.

Regarding sshd_config.d, it is necessary as new cloud images set no password in files in this directory, and ssh with a password does not work.