### PR TITLE
Fix MATCH explanation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ be helpful when trying to understand what went wrong.
 A few helper functions are available for scripts to use:
 
  * _REBOOT_ - Reboot the system. See [below](#rebooting) for details.
- * _MATCH_ - Run `grep -q -e` on stdin. Without match, print error including content.
+ * _MATCH_ - Run `grep -q -E` on stdin. Without match, print error including content.
  * _NOMATCH_ - Assert no match on stdin.  If match found, print error including content.
  * _ERROR_ - Fail script with provided error message only instead of script trace.
  * _FATAL_ - Similar to ERROR, but prevents retries. Specific to [adhoc backend](#adhoc).


### PR DESCRIPTION
As defined in the source code ([here](https://github.com/canonical/spread/blob/ae284792596e00d325a1787604fe4ec7e00574aa/spread/client.go#L362) and [here](https://github.com/canonical/spread/blob/ae284792596e00d325a1787604fe4ec7e00574aa/spread/client.go#L790)), the MATCH should be `grep -q -E`, rather than `grep -q -e`