### PR TITLE
test: build local spread binary

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -37,9 +37,7 @@ jobs:
       - name: Run spread tests
         run: |
           uname -a
-          trap 'rm -f /tmp/key.json' EXIT
-          (umask 177; echo "${{ secrets.SPREAD_GOOGLE_KEY }}" | base64 -d > /tmp/key.json)
-          /usr/bin/spread google:
+          SPREAD_GOOGLE_KEY=$(echo "${{ secrets.SPREAD_GOOGLE_KEY }}" | base64 -d) /usr/bin/spread google:
 
       - name: Discard spread workers
         if: always()

--- a/spread.yaml
+++ b/spread.yaml
@@ -16,7 +16,7 @@ environment:
 
 backends:
     google:
-        key: /tmp/key.json
+        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
         location: snapd-spread/us-east1-b
         halt-timeout: 2h
         systems:


### PR DESCRIPTION
Don't rely on GitHub runners providing a (potentially outdated)
spread binary. Instead, check out a reference version and build a
local binary to be used in the github CI test.