### PR TITLE
spread/project: skip dangling symlinks in suite dirs instead of panicking

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -652,7 +652,12 @@ func Load(path string) (*Project, error) {
 		suite.Tasks = make(map[string]*Task)
 		for _, tname := range tnames {
 			tfilename := filepath.Join(suite.Path, tname, "task.yaml")
-			if fi, _ := os.Stat(filepath.Dir(tfilename)); !fi.IsDir() {
+			// A dangling symlink (e.g. a deleted _common/test directory
+			// left pointing to nothing) still shows up in Readdirnames,
+			// but Stat fails on it. Swallow the error and skip instead of
+			// dereferencing the nil FileInfo.
+			fi, err := os.Stat(filepath.Dir(tfilename))
+			if err != nil || !fi.IsDir() {
 				continue
 			}
 			tdata, err := os.ReadFile(tfilename)


### PR DESCRIPTION
### Problem

When a spread test suite directory contains a dangling symlink (e.g. a
`_common` target that was later deleted but whose symlinks under
`core24/`, `core26/`, ... were forgotten), spread panics instead of
skipping the broken entry:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x74bb25]
Error: Process completed with exit code 2.
```

`Readdirnames` returns the symlink name, then `spread/project.go` does:

```go
if fi, _ := os.Stat(filepath.Dir(tfilename)); !fi.IsDir() {
    continue
}
```

For a dangling symlink `os.Stat` returns `(nil, err)`. Swallowing the
error means `fi.IsDir()` dereferences `nil`, so the whole spread run
dies. The CI log in #288 reproduces it via a forgotten cross-series
symlink.

### Fix

Keep the error and treat a failed stat the same as "not a directory":

```go
fi, err := os.Stat(filepath.Dir(tfilename))
if err != nil || !fi.IsDir() {
    continue
}
```

Same outcome as today whenever the stat succeeds. Only the broken case
flips from panic to a quiet skip, matching the surrounding logic that
also skips entries without a `task.yaml`.

Fixes #288
