### PR TITLE
google: sanitize username before using it as a GCE owner label

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -185,6 +185,30 @@ func (p *googleProvider) validLabel(label string) bool {
 	return len(label) < 64 && googleLabelExp.MatchString(label)
 }
 
+// googleInvalidLabelExp matches runs of characters that are not legal in a
+// Google label value (lowercase letters, digits, underscore, dash).
+var googleInvalidLabelExp = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// googleLabelSanitize coerces an arbitrary string (typically $USER) into a
+// value that satisfies Google's label-value rules: "can only contain
+// lowercase letters, numeric characters, underscores and dashes", at most
+// 63 characters. Runs of other characters collapse to a single dash;
+// leading/trailing dashes and underscores are trimmed. Returns "spread" if
+// the input is empty or would otherwise reduce to an empty string, so the
+// owner label is always present and always valid.
+func googleLabelSanitize(s string) string {
+	s = strings.ToLower(s)
+	s = googleInvalidLabelExp.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-_")
+	if len(s) > 63 {
+		s = strings.TrimRight(s[:63], "-_")
+	}
+	if s == "" {
+		return "spread"
+	}
+	return s
+}
+
 type googleInstanceInterfaces struct {
 	NetworkInterfaces []struct {
 		Network       string
@@ -403,7 +427,7 @@ func (p *googleProvider) createMachine(ctx context.Context, system *System) (*go
 
 	labels := googleParams{
 		"spread": "true",
-		"owner":  strings.ToLower(username()),
+		"owner":  googleLabelSanitize(username()),
 		"reuse":  strconv.FormatBool(p.options.Reuse),
 	}
 	if p.validLabel(p.options.Password) {


### PR DESCRIPTION
## What

When spread allocates a Google Cloud instance, it stamps the VM with an `owner` label built from the local `$USER`:

```go
labels := googleParams{
    "spread": "true",
    "owner":  strings.ToLower(username()),
    ...
}
```

GCE label values must match `^[a-z0-9_-]+$` and be at most 63 characters. Plenty of real usernames don't: corporate-provisioned laptops increasingly set `$USER` to the employee's SSO address (e.g. `first.last@canonical.com`), so every `spread google:` run on such a laptop fails with:

```
Cannot allocate google:ubuntu-24.04-64: cannot allocate new Google server for
ubuntu-24.04-64: invalid value for field 'resource.labels': ''. Label value
'first.last@canonical.com' violates format constraints. The value can only
contain lowercase letters, numeric characters, underscores and dashes. ...
```

Per #227, the current workaround has been shadowing `$USER`:

```
USER=hotdog spread google:
```

That's a bad ask for a label whose only job is to identify who owns a VM.

## Fix

Add `googleLabelSanitize()` that coerces an arbitrary string into a legal label value:

- lowercase the input,
- collapse any run of disallowed characters into a single `-`,
- trim leading/trailing `-` / `_`,
- cap at 63 chars (and re-trim separators at the end so the label doesn't terminate on a dash),
- fall back to `"spread"` if the input is empty or reduces to empty.

```go
var googleInvalidLabelExp = regexp.MustCompile(`[^a-z0-9_-]+`)

func googleLabelSanitize(s string) string {
    s = strings.ToLower(s)
    s = googleInvalidLabelExp.ReplaceAllString(s, "-")
    s = strings.Trim(s, "-_")
    if len(s) > 63 {
        s = strings.TrimRight(s[:63], "-_")
    }
    if s == "" {
        return "spread"
    }
    return s
}
```

And swap the caller:

```go
"owner":  googleLabelSanitize(username()),
```

## Observable effect

| `$USER` | owner label before | owner label after |
|---|---|---|
| `alice` | `alice` | `alice` (unchanged) |
| `first.last@canonical.com` | (allocation fails) | `first-last-canonical-com` |
| `` (empty) | (allocation fails) | `spread` |
| `Thirteen.plus.sixty.four.chars.example.example.example.example.example.extra` | (allocation fails) | first 63 chars, separator-trimmed |

Any previously-legal username goes through unchanged (lowercase letters, digits, `_`, `-` are all preserved). Anything previously broken now produces a label that still identifies the owner recognisably (`first-last-canonical-com`), rather than hiding behind the fallback.

`validLabel` is left alone because it still guards the separate `password` label path correctly.

Fixes #227